### PR TITLE
Fix "Dreamcast.ContentPath = ./" on macOS

### DIFF
--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -73,6 +73,9 @@ void os_CreateWindow() {
         printf("task_set_exception_ports: %s\n", mach_error_string(ret));
     }
 #endif
+    
+    //For settings.dreamcast.ContentPath.emplace_back("./"), Since macOS app bundle cwd is at "/"
+    chdir([[[[NSBundle mainBundle] bundlePath] stringByDeletingLastPathComponent] cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 void os_SetupInput()


### PR DESCRIPTION
In macOS, when Flycast is launched by Finder, the `cwd` is `/`
With an empty `ContentPath`, a brand new Flycast will scan the full hard disk every time with `/./`

This pull request align the `cwd` behaviour on macOS with Windows/Linux