### PR TITLE
Display ping test result to user

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -369,14 +369,18 @@ void Gdxsv::GcpPingTest() {
         int rtt = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
         const std::string response_header(buf, n);
         if (response_header.find("200 OK") != std::string::npos) {
-            NOTICE_LOG(COMMON, "%s : %d[ms]", region_host.first.c_str(), rtt);
             gcp_ping_test_result[region_host.first] = rtt;
+            char latency_str[16];
+            sprintf(latency_str, "%s : %d[ms]", region_host.first.c_str(), rtt);
+            NOTICE_LOG(COMMON, latency_str);
+            gui_display_notification(latency_str, 3000);
         } else {
             ERROR_LOG(COMMON, "error response : %s", response_header.c_str());
         }
         client.Close();
     }
     gcp_ping_test_finished = true;
+    gui_display_notification("Google Cloud latency checked!", 3000);
 }
 
 void Gdxsv::UpdateNetwork() {


### PR DESCRIPTION
Some players questioned how & when does the ping is done, and some of them seems struggled when restarting the game cannot change the ping result.

So let's display the result during the 1st boot of game, so that they could know the 2nd game boot won't ping at all.