### PR TITLE
Fix 0.5.6 crash in Windows build

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -370,8 +370,8 @@ void Gdxsv::GcpPingTest() {
         const std::string response_header(buf, n);
         if (response_header.find("200 OK") != std::string::npos) {
             gcp_ping_test_result[region_host.first] = rtt;
-            char latency_str[16];
-            sprintf(latency_str, "%s : %d[ms]", region_host.first.c_str(), rtt);
+            char latency_str[50];
+            snprintf(latency_str, 50, "%s : %d[ms]", region_host.first.c_str(), rtt);
             NOTICE_LOG(COMMON, latency_str);
             gui_display_notification(latency_str, 3000);
         } else {

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -370,8 +370,8 @@ void Gdxsv::GcpPingTest() {
         const std::string response_header(buf, n);
         if (response_header.find("200 OK") != std::string::npos) {
             gcp_ping_test_result[region_host.first] = rtt;
-            char latency_str[50];
-            snprintf(latency_str, 50, "%s : %d[ms]", region_host.first.c_str(), rtt);
+            char latency_str[256];
+            snprintf(latency_str, 256, "%s : %d[ms]", region_host.first.c_str(), rtt);
             NOTICE_LOG(COMMON, latency_str);
             gui_display_notification(latency_str, 3000);
         } else {


### PR DESCRIPTION
My bad, out of bounds write crashes in Windows (but not in macOS 😮)
`northamerica-northeast1 : 9999[ms]` the longest string length could up to 34

Increased the size and prevent future crashes now...