### PR TITLE
Fix Missing `___chkstk_darwin` on macOS 10.13 and various macOS fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
           
           set PATH=%EXTRA_PATH%;%PATH%
 
-          for /f "delims=" %%i in ('git describe --tags') do set SUFFIX=%%i
+          for /f "delims=" %%i in ('powershell "git describe --tags | %% {$_ -replace('(?=-)-(.*)','+$1')}"') do set SUFFIX=%%i
 
           if defined APPVEYOR_REPO_TAG_NAME (set SUFFIX=%APPVEYOR_REPO_TAG_NAME%-%APPVEYOR_REPO_COMMIT:~0,7%)
           
@@ -67,7 +67,7 @@ for:
     
     before_build:
       - sh: >-
-          if [ -z "$APPVEYOR_REPO_TAG_NAME" ]; then export SUFFIX=$(git describe --tags); else export SUFFIX=$APPVEYOR_REPO_TAG_NAME-${APPVEYOR_REPO_COMMIT:0:7}; fi
+          if [ -z "$APPVEYOR_REPO_TAG_NAME" ]; then export SUFFIX=$(git describe --tags | sed -e 's/-/+/'); else export SUFFIX=$APPVEYOR_REPO_TAG_NAME-${APPVEYOR_REPO_COMMIT:0:7}; fi
 
           cd shell/apple
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ for:
 
           mkdir artifacts
 
-          brew install sdl2
+          brew install --build-from-source ../../core/deps/SDL2-2.0.12/sdl2.rb
 
     build_script:
       - sh: >-

--- a/core/core.mk
+++ b/core/core.mk
@@ -185,7 +185,7 @@ RZDCY_FILES += $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(w
 RZDCY_FILES += $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(wildcard $(dir)*.S))
 
 $(VERSION_HEADER):
-	echo "#define REICAST_VERSION \"`git describe --tags --always`\"" > $(VERSION_HEADER)
+	echo "#define REICAST_VERSION \"`git describe --tags --always | sed -e 's/-/+/'`\"" > $(VERSION_HEADER)
 	echo "#define GIT_HASH \"`git rev-parse --short HEAD`\"" >> $(VERSION_HEADER)
 	echo "#define BUILD_DATE \"`date '+%Y-%m-%d %H:%M:%S %Z'`\"" >> $(VERSION_HEADER)
 

--- a/core/deps/SDL2-2.0.12/sdl2.rb
+++ b/core/deps/SDL2-2.0.12/sdl2.rb
@@ -1,0 +1,52 @@
+class Sdl2 < Formula
+  desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
+  homepage "https://www.libsdl.org/"
+  url "https://libsdl.org/release/SDL2-2.0.14.tar.gz"
+  sha256 "d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc"
+  license "Zlib"
+  revision 1
+
+  livecheck do
+    url "https://www.libsdl.org/download-2.0.php"
+    regex(/SDL2[._-]v?(\d+(?:\.\d+)*)/i)
+  end
+
+  bottle do
+    cellar :any
+    sha256 "ccde7145d4334d9274f9588e6b841bf3749729682e1d25f590bdcf7994dfdd89" => :big_sur
+    sha256 "2ae70b6025c4e241400643f2686c8e288d50e3f04311e63d8a1f8180ed4afb07" => :arm64_big_sur
+    sha256 "d6ae3300160c5bb495b78a5c5c0fc995f9e797e9cdd4b04ef77d59d45d2d694d" => :catalina
+    sha256 "4f3988fb3af0f370bc1648d6eb1d6573fd37381df0f3b9ee0874a49d6a7dec2e" => :mojave
+  end
+
+  head do
+    url "https://hg.libsdl.org/SDL", using: :hg
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    # we have to do this because most build scripts assume that all SDL modules
+    # are installed to the same prefix. Consequently SDL stuff cannot be
+    # keg-only but I doubt that will be needed.
+    inreplace %w[sdl2.pc.in sdl2-config.in], "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
+
+    args = %W[--prefix=#{prefix} --without-x --enable-hidapi]
+    args << "CFLAGS=-mmacosx-version-min=10.9"
+    args << "CXXFLAGS=-mmacosx-version-min=10.9"
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system bin/"sdl2-config", "--version"
+  end
+end

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -816,7 +816,7 @@ void Gdxsv::handleReleaseJSON(const std::string &json) {
         latest_version = match.str(0).substr(13, std::string::npos);
 
         std::string current_version = std::string(REICAST_VERSION);
-        current_version = current_version.substr(1, current_version.find_first_of("-") - 1);
+        current_version = current_version.substr(1, current_version.find_first_of("+") - 1);
 
         auto version_compare = [](std::string v1, std::string v2) {
             size_t i = 0, j = 0;

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -227,12 +227,19 @@ extern "C" int emu_reicast_init()
 	NSArray *arguments = [[NSProcessInfo processInfo] arguments];
 	unsigned long argc = [arguments count];
 	char **argv = (char **)malloc(argc * sizeof(char*));
+    int paramCount = 0;
 	for (unsigned long i = 0; i < argc; i++)
-		argv[i] = strdup([[arguments objectAtIndex:i] UTF8String]);
+    {
+		const char *arg = [[arguments objectAtIndex:i] UTF8String];
+        if (!strncmp(arg, "-psn_", 5))
+            // ignore Process Serial Number argument on first launch
+            continue;
+        argv[paramCount++] = strdup(arg);
+    }
 	
-	int rc = reicast_init((int)argc, argv);
+	int rc = reicast_init(paramCount, argv);
 	
-	for (unsigned long i = 0; i < argc; i++)
+	for (unsigned long i = 0; i < paramCount; i++)
 		free(argv[i]);
 	free(argv);
 	

--- a/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
+++ b/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		F25999DE25157207009022A2 /* libopenlibm.3.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F25999DC251571F0009022A2 /* libopenlibm.3.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F25B66A5250947E800959C8F /* gdxsv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F25B669C250947E800959C8F /* gdxsv.cpp */; };
 		F25B66A6250947E800959C8F /* gdxsv_network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F25B66A1250947E800959C8F /* gdxsv_network.cpp */; };
+		F2E7B22825B61E8100BAF171 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2E7B22725B61E8100BAF171 /* GameController.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1383,6 +1384,7 @@
 		F25B669F250947E800959C8F /* gdx_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gdx_queue.h; sourceTree = "<group>"; };
 		F25B66A1250947E800959C8F /* gdxsv_network.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gdxsv_network.cpp; sourceTree = "<group>"; };
 		F25B66A2250947E800959C8F /* gdxsv_patch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gdxsv_patch.h; sourceTree = "<group>"; };
+		F2E7B22725B61E8100BAF171 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1397,6 +1399,7 @@
 				AE7BCB5C243DDCAE007285F8 /* ForceFeedback.framework in Frameworks */,
 				AE7BCB5E243DDCD1007285F8 /* AudioToolbox.framework in Frameworks */,
 				AE7BCB60243DDD49007285F8 /* libiconv.2.tbd in Frameworks */,
+				F2E7B22825B61E8100BAF171 /* GameController.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2718,6 +2721,7 @@
 		AED73DC52303E57C00ECDB64 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F2E7B22725B61E8100BAF171 /* GameController.framework */,
 				AE7BCB61243DDD92007285F8 /* Carbon.framework */,
 				AE7BCB5F243DDD3A007285F8 /* libiconv.2.tbd */,
 				AE7BCB5D243DDCD1007285F8 /* AudioToolbox.framework */,

--- a/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
+++ b/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
@@ -3230,7 +3230,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"#define REICAST_VERSION \\\"`git describe --tags --always`\\\"\" > $SRCROOT/../../../core/version.h\necho \"#define GIT_HASH \\\"`git rev-parse --short HEAD`\\\"\" >> $SRCROOT/../../../core/version.h\necho \"#define BUILD_DATE \\\"`date '+%Y-%m-%d %H:%M:%S %Z'`\\\"\" >> $SRCROOT/../../../core/version.h\n";
+			shellScript = "echo \"#define REICAST_VERSION \\\"`git describe --tags --always | sed -e 's/-/+/'`\\\"\" > $SRCROOT/../../../core/version.h\necho \"#define GIT_HASH \\\"`git rev-parse --short HEAD`\\\"\" >> $SRCROOT/../../../core/version.h\necho \"#define BUILD_DATE \\\"`date '+%Y-%m-%d %H:%M:%S %Z'`\\\"\" >> $SRCROOT/../../../core/version.h\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
+++ b/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
@@ -3687,6 +3687,7 @@
 			baseConfigurationReference = AE2A234A22941AF000DD3034 /* DreamcastConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -3745,6 +3746,7 @@
 			baseConfigurationReference = AE2A234A22941AF000DD3034 /* DreamcastConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
1. Fixes the Stack Checking missing symbol error, should be caused by the latest `SDL2-2.0.14` precompiled bottle from homebrew.
2. Add GameController.framework for `SDL2-2.0.14`
3. Remove arm64 target (to support Appveyor's latest Xcode version) 
4. ignore the unique process serial number argument (`-psn`)  which causes Flycast to be booted into DC rom directly during first launch (from: https://github.com/flyinghead/flycast/commit/bbedcaa37b7a6b8e78e745150dae1d24acaba7d4)
5. Change the CI build version format from `v0.7.0-2-g01c9e00f` to `v0.7.0+2-g01c9e00f`, since `-` means prerelease in semver spec
