### PR TITLE
Fix connect timeout

### DIFF
--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -68,7 +68,7 @@ bool TcpClient::Connect(const char *host, int port) {
 #else
                         if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, &error, &l) < 0 || error) {
 #endif
-                            WARN_LOG(COMMON, "Connect fail 4 %d", get_last_error());
+                            WARN_LOG(COMMON, "Connect fail 4 %d", error);
                             return false;
                         }
                         WARN_LOG(COMMON, "Connect fail 5 %d", get_last_error());

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -61,13 +61,13 @@ bool TcpClient::Connect(const char *host, int port) {
                 } else if (res > 0) {
                     
                     if (FD_ISSET(new_sock, &setE)){
-#ifdef _WIN32
-                        char error;
-#else
                         int error;
-#endif
                         socklen_t l = sizeof(int);
+#ifdef _WIN32
+                        if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, (char*)&error, &l) < 0 || error) {
+#else
                         if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, &error, &l) < 0 || error) {
+#endif
                             WARN_LOG(COMMON, "Connect fail 4 %d", get_last_error());
                             return false;
                         }


### PR DESCRIPTION
Discovered this due to `asia-south1-gce.cloudharmony.net` is dead, currently the `Gdxsv::GcpPingTest()` is stucked until a 90 seconds? socket timeout.

Since `SO_RCVTIMEO` and `SO_SNDTIMEO` won't work for `connect`, we must use non blocking mode to handle timeout in `connect`