### PR TITLE
Fix macOS socket exception

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -48,6 +48,8 @@ void Gdxsv::Reset() {
         ERROR_LOG(COMMON, "WSAStartup failed. errno=%d", get_last_error());
         return;
     }
+#else
+    signal(SIGPIPE, SIG_IGN);
 #endif
 
     if (!net_thread.joinable()) {

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -60,17 +60,18 @@ bool TcpClient::Connect(const char *host, int port) {
                     return false;
                 } else if (res > 0) {
                     
-                    if (FD_ISSET(new_sock, &setE)){
-                        int error;
-                        socklen_t l = sizeof(int);
+                    int error;
+                    socklen_t l = sizeof(int);
 #ifdef _WIN32
-                        if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, (char*)&error, &l) < 0 || error) {
+                    if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, (char*)&error, &l) < 0 || error) {
 #else
-                        if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, &error, &l) < 0 || error) {
+                    if (getsockopt(new_sock, SOL_SOCKET, SO_ERROR, &error, &l) < 0 || error) {
 #endif
-                            WARN_LOG(COMMON, "Connect fail 4 %d", error);
-                            return false;
-                        }
+                        WARN_LOG(COMMON, "Connect fail 4 %d", error);
+                        return false;
+                    }
+                    
+                    if (FD_ISSET(new_sock, &setE)){
                         WARN_LOG(COMMON, "Connect fail 5 %d", get_last_error());
                         return false;
                     }


### PR DESCRIPTION
`us-east1-gce.cloudharmony.net` is refusing connection tonight, there is no problem for the Windows build since the socket exception can be detected by:
```c
select(new_sock+1, NULL, &setW, &setE, &timeout);
FD_ISSET(new_sock, &setE)
```

```
gdxsv/gdxsv_network.cpp:8 N[COMMON]: TCP Connect: us-east1-gce.cloudharmony.net:80
gdxsv/gdxsv_network.cpp:71 W[COMMON]: Connect fail 4 10061
gdxsv/gdxsv.cpp:355 E[COMMON]: connect failed : us-east1
```
But surprisingly no exception is set on macOS... so Flycast is killed by signal 13 (`SIGPIPE`) when it is trying to write to the broken pipe

This pull request will always check for `SO_ERROR` even when there is no socket exception, and will ignore `SIGPIPE` signal globally