### PR TITLE
Git version handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,10 @@ find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --always --match "gdxsv-*"
-        COMMAND sed "s/-\\([[:digit:]]\\{1,\\}\\)-g\\(.\\{8\\}$\\)/-dev.\\1+\\2/"
         OUTPUT_VARIABLE GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    string(REGEX REPLACE "-([0-9]+)-g(.+)$" "-dev.\\1+\\2" GIT_VERSION "${GIT_VERSION}")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
         OUTPUT_VARIABLE GIT_HASH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ endif()
 find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --always
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always --match "gdxsv-*"
+        COMMAND sed "s/-\\([[:digit:]]\\{1,\\}\\)-g\\(.\\{8\\}$\\)/-dev.\\1+\\2/"
         OUTPUT_VARIABLE GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )

--- a/core/core.mk
+++ b/core/core.mk
@@ -265,6 +265,6 @@ RZDCY_FILES += $(LIBZIP_DIR)/zip_add.c \
 endif
 
 $(VERSION_HEADER):
-	echo "#define GIT_VERSION \"`git describe --tags --always | sed -e 's/-/+/'`\"" > $(VERSION_HEADER)
+	echo "#define GIT_VERSION \"`git describe --tags --always --match 'gdxsv-*' | sed 's/-\([[:digit:]]\{1,\}\)-g\(.\{8\}$\)/-dev.\1+\2/'`\"" > $(VERSION_HEADER)
 	echo "#define GIT_HASH \"`git rev-parse --short HEAD`\"" >> $(VERSION_HEADER)
 	echo "#define BUILD_DATE \"`date '+%Y-%m-%d %H:%M:%S %Z'`\"" >> $(VERSION_HEADER)

--- a/core/core.mk
+++ b/core/core.mk
@@ -265,6 +265,6 @@ RZDCY_FILES += $(LIBZIP_DIR)/zip_add.c \
 endif
 
 $(VERSION_HEADER):
-	echo "#define GIT_VERSION \"`git describe --tags --always --match 'gdxsv-*' | sed 's/-\([[:digit:]]\{1,\}\)-g\(.\{8\}$\)/-dev.\1+\2/'`\"" > $(VERSION_HEADER)
+	echo "#define GIT_VERSION \"`git describe --tags --always --match 'gdxsv-*' | sed 's/-\([[:digit:]]\{1,\}\)-g\(.\{8\}$$\)/-dev.\1+\2/'`\"" > $(VERSION_HEADER)
 	echo "#define GIT_HASH \"`git rev-parse --short HEAD`\"" >> $(VERSION_HEADER)
 	echo "#define BUILD_DATE \"`date '+%Y-%m-%d %H:%M:%S %Z'`\"" >> $(VERSION_HEADER)

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -844,7 +844,7 @@ void Gdxsv::handleReleaseJSON(const std::string &json) {
 
     std::smatch match;
 
-    auto current_version_str = std::string(GIT_VERSION);
+    auto current_version_str = trim_prefix(std::string(GIT_VERSION));
     if (!std::regex_match(current_version_str, match, semver_regex)) return;
 
     if (match.size() < 4) return;

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -869,7 +869,7 @@ static void update_popup()
     if (ImGui::BeginPopupModal("New version", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
     {
         ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 400.f * scaling);
-        ImGui::TextWrapped("  v%s is available for download!  ", gdxsv.LatestVersion().c_str());
+        ImGui::TextWrapped("  %s is available for download!  ", gdxsv.LatestVersion().c_str());
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * scaling, 3 * scaling));
         float currentwidth = ImGui::GetContentRegionAvail().x;
         ImGui::SetCursorPosX((currentwidth - 100.f * scaling) / 2.f + ImGui::GetStyle().WindowPadding.x - 55.f * scaling);

--- a/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
+++ b/shell/apple/emulator-osx/reicast-osx.xcodeproj/project.pbxproj
@@ -3205,7 +3205,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"#define GIT_VERSION \\\"`git describe --tags --always | sed -e 's/-/+/'`\\\"\" > $SRCROOT/../../../core/version.h\necho \"#define GIT_HASH \\\"`git rev-parse --short HEAD`\\\"\" >> $SRCROOT/../../../core/version.h\necho \"#define BUILD_DATE \\\"`date '+%Y-%m-%d %H:%M:%S %Z'`\\\"\" >> $SRCROOT/../../../core/version.h\ncd $SRCROOT/../../../core/deps/miniupnpc; sh ./updateminiupnpcstrings.sh\n";
+			shellScript = "echo \"#define GIT_VERSION \\\"`git describe --tags --always --match 'gdxsv-*' | sed 's/-\\([[:digit:]+]\\)-g\\(.\\{8\\}\\)/-dev.\\1+\\2/'`\\\"\" > $SRCROOT/../../../core/version.h\necho \"#define GIT_HASH \\\"`git rev-parse --short HEAD`\\\"\" >> $SRCROOT/../../../core/version.h\necho \"#define BUILD_DATE \\\"`date '+%Y-%m-%d %H:%M:%S %Z'`\\\"\" >> $SRCROOT/../../../core/version.h\ncd $SRCROOT/../../../core/deps/miniupnpc; sh ./updateminiupnpcstrings.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
- Trim prefix for `current_version_str` before do the semver regex check 
- Always grab git tag with `gdxsv-` prefix
- Use semver formatting for dev build (e.g. `gdxsv-0.9.7-dev.2+dfc350a4`)
- Remove the redundant `v` prefix in the update prompt