### PR TITLE
Initial Content Path setup

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -34,13 +34,11 @@ void Gdxsv::Reset() {
     tcp_client.Close();
     CloseUdpClientWithReason("cl_hard_reset");
 
-#ifdef _WIN32
     // Automatically add ContentPath if it is empty.
     if (config::ContentPath.get().empty()) {
         config::ContentPath.get().push_back("./");
     }
-#endif
-
+    
     auto game_id = std::string(ip_meta.product_number, sizeof(ip_meta.product_number));
     if (game_id != "T13306M   ") {
         enabled = false;

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -378,6 +378,10 @@ int reicast_init(int argc, char* argv[])
 	{
 		LogManager::Init();
 		config::Settings::instance().load(false);
+		//gdxsv auto find content in cwd
+		if (config::ContentPath.get().empty()) {
+			config::ContentPath.get().push_back("./");
+		}
 	}
 	// Force the renderer type now since we're not switching
 	config::RendererType.commit();


### PR DESCRIPTION
- Add cwd as content path when Flycast first load
- Use "./" as content path for macOS also