### PR TITLE
Optimising widescreen cheat

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -815,22 +815,34 @@ void Gdxsv::WritePatchDisk2() {
 
     // Dirty widescreen cheat
     if (config::WidescreenGameHacks.get()) {
+        bool original_widescreen_hacked = widescreen_hacked;
         u32 ratio = 0x3faaaaab; // default 4/3
+        int stretching = 100;
+        bool update = false;
         if (ReadMem8_nommu(0x0c3d16d4) == 2) { // In main game part
             // Changing this value outside the game part will break UI layout.
-            // ratio = 0x3fe4b17e; // wide 4/3 * 1.34
-            // config::ScreenStretching.override(134);
-
-            // Use a little wider than 16/9 because of a glitch at the edges of the screen.
-            ratio = 0x40155555;
-            config::ScreenStretching.override(175);
+            widescreen_hacked = true;
+            if (original_widescreen_hacked != widescreen_hacked){
+                // ratio = 0x3fe4b17e; // wide 4/3 * 1.34
+                // stretching = 134;
+                // Use a little wider than 16/9 because of a glitch at the edges of the screen.
+                ratio = 0x40155555;
+                stretching = 175;
+                update = true;
+            }
         } else {
-            config::ScreenStretching.override(100);
+            widescreen_hacked = false;
+            if (original_widescreen_hacked != widescreen_hacked){
+                update = true;
+            }
         }
-        WriteMem32_nommu(0x0c1e7948, ratio);
-        WriteMem32_nommu(0x0c1e7958, ratio);
-        WriteMem32_nommu(0x0c1e7968, ratio);
-        WriteMem32_nommu(0x0c1e7978, ratio);
+        if(update){
+            config::ScreenStretching.override(stretching);
+            WriteMem32_nommu(0x0c1e7948, ratio);
+            WriteMem32_nommu(0x0c1e7958, ratio);
+            WriteMem32_nommu(0x0c1e7968, ratio);
+            WriteMem32_nommu(0x0c1e7978, ratio);
+        }
     }
 }
 

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -819,8 +819,9 @@ void Gdxsv::WritePatchDisk2() {
         u32 ratio = 0x3faaaaab; // default 4/3
         int stretching = 100;
         bool update = false;
-        if (ReadMem8_nommu(0x0c3d16d4) == 2) { // In main game part
+        if (ReadMem8_nommu(0x0c3d16d4) == 2 && ReadMem8_nommu(0x0c3d16d5) == 7) { // In main game part
             // Changing this value outside the game part will break UI layout.
+            // For 0x0c3d16d5: 4=load briefing, 5=briefing, 7=battle, 0xd=rebattle/end selection
             widescreen_hacked = true;
             if (original_widescreen_hacked != widescreen_hacked){
                 // ratio = 0x3fe4b17e; // wide 4/3 * 1.34

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -815,15 +815,13 @@ void Gdxsv::WritePatchDisk2() {
 
     // Dirty widescreen cheat
     if (config::WidescreenGameHacks.get()) {
-        bool original_widescreen_hacked = widescreen_hacked;
         u32 ratio = 0x3faaaaab; // default 4/3
         int stretching = 100;
         bool update = false;
         if (ReadMem8_nommu(0x0c3d16d4) == 2 && ReadMem8_nommu(0x0c3d16d5) == 7) { // In main game part
             // Changing this value outside the game part will break UI layout.
             // For 0x0c3d16d5: 4=load briefing, 5=briefing, 7=battle, 0xd=rebattle/end selection
-            widescreen_hacked = true;
-            if (original_widescreen_hacked != widescreen_hacked){
+            if (config::ScreenStretching == 100){
                 // ratio = 0x3fe4b17e; // wide 4/3 * 1.34
                 // stretching = 134;
                 // Use a little wider than 16/9 because of a glitch at the edges of the screen.
@@ -832,12 +830,11 @@ void Gdxsv::WritePatchDisk2() {
                 update = true;
             }
         } else {
-            widescreen_hacked = false;
-            if (original_widescreen_hacked != widescreen_hacked){
+            if (config::ScreenStretching != 100) {
                 update = true;
             }
         }
-        if(update){
+        if (update) {
             config::ScreenStretching.override(stretching);
             WriteMem32_nommu(0x0c1e7948, ratio);
             WriteMem32_nommu(0x0c1e7958, ratio);

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -57,7 +57,6 @@ private:
     std::atomic<bool> enabled;
     std::atomic<int> disk;
     std::atomic<u8> maxlag;
-    std::atomic<bool> widescreen_hacked;
 
     std::string server;
     std::string loginkey;

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -57,6 +57,7 @@ private:
     std::atomic<bool> enabled;
     std::atomic<int> disk;
     std::atomic<u8> maxlag;
+    std::atomic<bool> widescreen_hacked;
 
     std::string server;
     std::string loginkey;


### PR DESCRIPTION
For `0x0c3d16d5`: 4=load briefing, 5=briefing, 7=battle, 0xd=rebattle/end selection
Only stretch screen during battle scene and only patch once (when required)