### PR TITLE
Fix macOS build's codesign issue during GitHub release

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -117,7 +117,7 @@ jobs:
           cp shell/apple/HowToOpen.pdf artifact/bin/
           cd artifact/bin
           mv Flycast.app Flycast-gdxsv.app
-          zip -rm ${{ matrix.config.packageName }} Flycast-gdxsv.app HowToOpen.pdf
+          zip -y -rm ${{ matrix.config.packageName }} Flycast-gdxsv.app HowToOpen.pdf
         if: matrix.config.name == 'apple-darwin'
 
       - name: Package app (windows)


### PR DESCRIPTION
zip with symbolic link support, fixes codesign issue
Verified from: https://github.com/vkedwardli/flycast/releases/tag/test-gdxsv-1.0.8

Without the fix:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/602245/190912942-b8eff625-e1e7-4ae5-a71f-49835e006d5b.png">

```
codesign -v -vvvv ./Flycast-gdxsv.app
Flycast-gdxsv.app: a sealed resource is missing or invalid
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/Japanese/CommonUpscale/Network/7b392e27.png
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/Japanese/CommonUpscale/Network/42e332e9.png
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/English/CommonUpscale/Network/7b392e27.png
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/English/CommonUpscale/Network/42e332e9.png
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/Cantonese/CommonUpscale/Network/7b392e27.png
file added: ./Flycast-gdxsv.app/Contents/Resources/Textures/Cantonese/CommonUpscale/Network/42e332e9.png
file missing: ./Flycast-gdxsv.app/Contents/Resources/Textures/English/CommonUpscale
file missing: ./Flycast-gdxsv.app/Contents/Resources/Textures/Japanese/CommonUpscale
file missing: ./Flycast-gdxsv.app/Contents/Resources/Textures/Cantonese/CommonUpscale
```