### PR TITLE
Fix gundam's widescreen hack

### DIFF
--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -67,6 +67,10 @@ void gdxsv_emu_loadstate(int slot) {
     }
 }
 
+bool gdxsv_emu_enabled() {
+    return gdxsv.Enabled();
+}
+
 bool gdxsv_emu_ingame() {
     return gdxsv.InGame();
 }

--- a/core/gdxsv/gdxsv_emu_hooks.h
+++ b/core/gdxsv/gdxsv_emu_hooks.h
@@ -12,6 +12,8 @@ void gdxsv_emu_savestate(int slot);
 
 void gdxsv_emu_loadstate(int slot);
 
+bool gdxsv_emu_enabled();
+
 bool gdxsv_emu_ingame();
 
 void gdxsv_update_popup();

--- a/core/rend/transform_matrix.h
+++ b/core/rend/transform_matrix.h
@@ -26,6 +26,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/transform.hpp>
 
+#include "../gdxsv/gdxsv.h"
+
 // Dreamcast:
 // +Y is down
 // OpenGL:
@@ -138,6 +140,10 @@ public:
 			starty *= 1.1;
 			// TODO need to adjust lightgun coordinates
 #endif
+			// GDXSV: Push the extra region offscreen for widescreen hack
+			if (gdxsv.Enabled() && config::ScreenStretching == 175)
+				startx = -1 * dcViewport.x * ( 1 - 1.f / 1.75f ) / 2.f;
+            
 			normalMatrix = glm::translate(glm::vec3(startx, starty, 0));
 			scissorMatrix = normalMatrix;
 
@@ -157,6 +163,10 @@ public:
 			float x_coef = 2.0f / dcViewport.x;
 			float y_coef = 2.0f / dcViewport.y * screenFlipY;
 
+			// GDXSV: Stretch the screen to make it wider than Framebuffer's size
+			if (gdxsv.Enabled())
+				x_coef *= (config::ScreenStretching / 100.f);
+            
 			glm::mat4 trans = glm::translate(glm::vec3(-1 + 2 * sidebarWidth, -screenFlipY, 0));
 
 			normalMatrix = trans
@@ -246,5 +256,9 @@ inline static float getOutputFramebufferAspectRatio()
 		else
 			renderAR = 4.f / 3.f;
 	}
+	// GDXSV: Do not use stretched size for framebuffer
+	if (gdxsv.Enabled())
+		return renderAR;
+	
 	return renderAR * config::ScreenStretching / 100.f;
 }

--- a/core/rend/transform_matrix.h
+++ b/core/rend/transform_matrix.h
@@ -26,7 +26,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/transform.hpp>
 
-#include "../gdxsv/gdxsv.h"
+#include "gdxsv/gdxsv_emu_hooks.h"
 
 // Dreamcast:
 // +Y is down
@@ -141,7 +141,7 @@ public:
 			// TODO need to adjust lightgun coordinates
 #endif
 			// GDXSV: Push the extra region offscreen for widescreen hack
-			if (gdxsv.Enabled() && config::ScreenStretching == 175)
+			if (gdxsv_emu_enabled() && config::ScreenStretching == 175)
 				startx = -1 * dcViewport.x * ( 1 - 1.f / 1.75f ) / 2.f;
             
 			normalMatrix = glm::translate(glm::vec3(startx, starty, 0));
@@ -164,7 +164,7 @@ public:
 			float y_coef = 2.0f / dcViewport.y * screenFlipY;
 
 			// GDXSV: Stretch the screen to make it wider than Framebuffer's size
-			if (gdxsv.Enabled())
+			if (gdxsv_emu_enabled())
 				x_coef *= (config::ScreenStretching / 100.f);
             
 			glm::mat4 trans = glm::translate(glm::vec3(-1 + 2 * sidebarWidth, -screenFlipY, 0));
@@ -257,7 +257,7 @@ inline static float getOutputFramebufferAspectRatio()
 			renderAR = 4.f / 3.f;
 	}
 	// GDXSV: Do not use stretched size for framebuffer
-	if (gdxsv.Enabled())
+	if (gdxsv_emu_enabled())
 		return renderAR;
 	
 	return renderAR * config::ScreenStretching / 100.f;


### PR DESCRIPTION
![Sep-30-2022 07-26-42](https://user-images.githubusercontent.com/602245/193160577-4aa41424-45eb-47c1-80ba-2a245282af80.gif)

Minimal quick fix to stretch the framebuffer + offset x position, in order to handle screen stretching changes by https://github.com/flyinghead/flycast/issues/584

Only verified on OpenGL and Vulkan (MoltenVK)