### PR TITLE
Disable debugger when it is not enabled in Settings

### DIFF
--- a/core/debug/gdb_server.cpp
+++ b/core/debug/gdb_server.cpp
@@ -834,8 +834,11 @@ static GdbServer gdbServer;
 
 void init()
 {
-	NOTICE_LOG(COMMON, "GDB Server initting...");
-	gdbServer.init();
+	if (config::DisplayDebuggerMenu)
+	{
+		NOTICE_LOG(COMMON, "GDB Server initting...");
+		gdbServer.init();
+	}
 }
 
 void term()


### PR DESCRIPTION
`gdbServer` is initiating unnecessary