### PR TITLE
Handle UTF-16 path in Windows

### DIFF
--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include "log/LogManager.h"
 #include "cfg/cfg.h"
+#include "nowide/fstream.hpp"
 
 #ifdef _WIN32
 #define CHAR_PATH_SEPARATOR '\\'
@@ -30,7 +31,7 @@ void gdxsv_flycast_init() {
 	
 	if (config::UploadCrashLogs) {
 		std::thread([]() {
-			std::ifstream fs;
+			nowide::ifstream fs;
 			fs.open(get_writable_data_path("crash_dmp_list.txt"));
 			std::vector<std::string> unhandled_dmp = {};
 			if (fs.is_open()) {


### PR DESCRIPTION
`ifstream` fails to open path with UTF-16 e.g. `DCエミュ`