### PR TITLE
Config overrides for rollback match

### DIFF
--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -615,63 +615,65 @@ void GdxsvBackendRollback::SaveReplay() {
 		return;
 	}
 
-	proto::BattleLogFile log;
-	log.set_game_disk(gdxsv.Disk() == 1 ? "dc1" : "dc2");
-	log.set_battle_code(matching_.battle_code());
-	log.set_log_file_version(20230426);
+	auto log = std::make_unique<proto::BattleLogFile>();
+	log->set_game_disk(gdxsv.Disk() == 1 ? "dc1" : "dc2");
+	log->set_battle_code(matching_.battle_code());
+	log->set_log_file_version(20230426);
 	for (int i = 0; i < gdxsv.patch_list_.patches_size(); ++i) {
-		log.add_patches()->CopyFrom(gdxsv.patch_list_.patches(i));
+		log->add_patches()->CopyFrom(gdxsv.patch_list_.patches(i));
 	}
-	log.set_rule_bin(matching_.rule_bin());
-	log.mutable_users()->CopyFrom(matching_.users());
+	log->set_rule_bin(matching_.rule_bin());
+	log->mutable_users()->CopyFrom(matching_.users());
 
 	for (const auto& kv : input_logs_) {
-		log.add_inputs(kv.second);
+		log->add_inputs(kv.second);
 	}
 
 	const auto now = std::chrono::system_clock::now();
-	log.set_end_at(std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count());
+	log->set_end_at(std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count());
 
-	auto replay_dir = get_writable_data_path("replays");
-	if (!file_exists(replay_dir)) {
-		if (!make_directory(replay_dir)) {
-			ERROR_LOG(COMMON, "Failed to create replay directory");
-			return;
+	std::thread([log = std::move(log)]() {
+		auto replay_dir = get_writable_data_path("replays");
+		if (!file_exists(replay_dir)) {
+			if (!make_directory(replay_dir)) {
+				ERROR_LOG(COMMON, "Failed to create replay directory");
+				return;
+			}
 		}
-	}
 
 #if _WIN32
-	auto replay_file = replay_dir + "\\" + matching_.battle_code() + ".pb";
+		auto replay_file = replay_dir + "\\" + log->battle_code() + ".pb";
 #else
-	auto replay_file = replay_dir + "/" + matching_.battle_code() + ".pb";
+		auto replay_file = replay_dir + "/" + log->battle_code() + ".pb";
 #endif
 
-	FILE* f = nowide::fopen(replay_file.c_str(), "wb");
-	if (f == nullptr) {
-		ERROR_LOG(COMMON, "SaveReplay: fopen failure");
-		return;
-	}
+		FILE* f = nowide::fopen(replay_file.c_str(), "wb");
+		if (f == nullptr) {
+			ERROR_LOG(COMMON, "SaveReplay: fopen failure");
+			return;
+		}
 
-	int fd = fileno(f);
-	if (fd == -1) {
-		ERROR_LOG(COMMON, "SaveReplay: fileno failure");
-		return;
-	}
+		int fd = fileno(f);
+		if (fd == -1) {
+			ERROR_LOG(COMMON, "SaveReplay: fileno failure");
+			return;
+		}
 
-	if (!log.SerializeToFileDescriptor(fd)) {
-		ERROR_LOG(COMMON, "SaveReplay: SerializeToFileDescriptor failure");
-		return;
-	}
-	fclose(f);
+		if (!log->SerializeToFileDescriptor(fd)) {
+			ERROR_LOG(COMMON, "SaveReplay: SerializeToFileDescriptor failure");
+			return;
+		}
+		fclose(f);
 
-	std::vector<http::PostField> fields;
-	fields.emplace_back("file", replay_file, "application/octet-stream");
-	int rc = http::post("https://asia-northeast1-gdxsv-274515.cloudfunctions.net/uploader", fields);
-	if (rc == 200 || rc == 409) {
-		NOTICE_LOG(COMMON, "SaveReplay: upload OK");
-	} else {
-		ERROR_LOG(COMMON, "SaveReplay: upload Failed staus: %d", rc);
-	}
+		std::vector<http::PostField> fields;
+		fields.emplace_back("file", replay_file, "application/octet-stream");
+		int rc = http::post("https://asia-northeast1-gdxsv-274515.cloudfunctions.net/uploader", fields);
+		if (rc == 200 || rc == 409) {
+			NOTICE_LOG(COMMON, "SaveReplay: upload OK");
+		} else {
+			ERROR_LOG(COMMON, "SaveReplay: upload Failed staus: %d", rc);
+		}
+	}).detach();
 }
 
 void GdxsvBackendRollback::ApplyPatch(bool first_time) {

--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -176,6 +176,7 @@ void GdxsvBackendRollback::OnMainUiLoop() {
 			config::FixedFrequency.override(2);
 			config::VSync.override(true);
 			config::LimitFPS.override(false);
+			config::ThreadedRendering.override(false);
 
 			start_network_ = ggpo::gdxsvStartNetwork(matching_.battle_code().c_str(), matching_.peer_id(), ips, ports, relays);
 			ggpo::receiveChatMessages(nullptr);
@@ -342,6 +343,7 @@ void GdxsvBackendRollback::Close() {
 	config::FixedFrequency.load();
 	config::VSync.load();
 	config::LimitFPS.load();
+	config::ThreadedRendering.load();
 	RestorePatch();
 	KillTex = true;
 	SaveReplay();

--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -173,6 +173,10 @@ void GdxsvBackendRollback::OnMainUiLoop() {
 			NOTICE_LOG(COMMON, "max_rtt=%.2f delay=%d", max_rtt, delay);
 			config::GGPOEnable.override(true);
 			config::GGPODelay.override(delay);
+			config::FixedFrequency.override(2);
+			config::VSync.override(true);
+			config::LimitFPS.override(false);
+
 			start_network_ = ggpo::gdxsvStartNetwork(matching_.battle_code().c_str(), matching_.peer_id(), ips, ports, relays);
 			ggpo::receiveChatMessages(nullptr);
 			session_start_time = std::chrono::high_resolution_clock::now();
@@ -335,6 +339,9 @@ void GdxsvBackendRollback::Close() {
 	SetCloseReason("close");
 	ggpo::stopSession();
 	config::GGPOEnable.reset();
+	config::FixedFrequency.load();
+	config::VSync.load();
+	config::LimitFPS.load();
 	RestorePatch();
 	KillTex = true;
 	SaveReplay();

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -150,8 +150,8 @@ void gdxsv_emu_settings() {
 	if (ImGui::Button("Apply Recommended Settings", ImVec2(0, 40))) {
 		// Frame Limit
 		config::LimitFPS = false;
-		config::VSync = false;
-		config::FixedFrequency = 3;
+		config::VSync = true;
+		config::FixedFrequency = 2;
 		// Controls
 		config::MapleMainDevices[0].set(MapleDeviceType::MDT_SegaController);
 		config::MapleExpansionDevices[0][0].set(MDT_SegaVMU);
@@ -185,7 +185,7 @@ void gdxsv_emu_settings() {
 	ImGui::SameLine();
 	ShowHelpMarker(R"(Use gdxsv recommended settings:
     Frame Limit Method:
-      CPU Sleep (60Hz)
+      VSync + CPU Sleep (59.94Hz)
 
     Control:
       Device A: Sega Controller / Sega VMU

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -149,10 +149,9 @@ void gdxsv_emu_settings() {
 
 	if (ImGui::Button("Apply Recommended Settings", ImVec2(0, 40))) {
 		// Frame Limit
-		config::LimitFPS = true;
-		config::VSync = true;
-		config::FixedFrequency = 0;
-
+		config::LimitFPS = false;
+		config::VSync = false;
+		config::FixedFrequency = 3;
 		// Controls
 		config::MapleMainDevices[0].set(MapleDeviceType::MDT_SegaController);
 		config::MapleExpansionDevices[0][0].set(MDT_SegaVMU);
@@ -176,7 +175,6 @@ void gdxsv_emu_settings() {
 		config::DynarecEnabled = true;
 		config::DynarecIdleSkip = true;
 		config::ThreadedRendering = false;
-
 		// Network
 		config::EnableUPnP = true;
 		config::GdxLocalPort = 0;
@@ -187,7 +185,7 @@ void gdxsv_emu_settings() {
 	ImGui::SameLine();
 	ShowHelpMarker(R"(Use gdxsv recommended settings:
     Frame Limit Method:
-      AudioSync + VSync
+      CPU Sleep (60Hz)
 
     Control:
       Device A: Sega Controller / Sega VMU


### PR DESCRIPTION
- Change recommended settings: VSync + CPU Sleep (59.94Hz)
- Override fps limit methods to: VSync + CPU Sleep (59.94Hz) & ThreadedRendering = false
- Save and upload replay file on sub thread
