### PR TITLE
Enable vsync

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -82,13 +82,12 @@ void Gdxsv::Reset() {
 	if (disk_num == "2") disk_ = 2;
 
 	maxrebattle_ = 5;
-	udp_port_ = config::GdxLocalPort;
 
 #ifdef __APPLE__
 	signal(SIGPIPE, SIG_IGN);
 #endif
 
-	NOTICE_LOG(COMMON, "gdxsv disk:%d server:%s loginkey:%s udp_port:%d", (int)disk_, server_.c_str(), loginkey_.c_str(), udp_port_);
+	NOTICE_LOG(COMMON, "gdxsv disk:%d server:%s loginkey:%s udp_port:%d", (int)disk_, server_.c_str(), loginkey_.c_str(), config::GdxLocalPort.get());
 
 	lbs_net_.lbs_packet_filter([this](const LbsMessage &lbs_msg) -> bool {
 		if (netmode_ != NetMode::Lbs) {
@@ -259,7 +258,7 @@ std::string Gdxsv::GeneratePlatformInfoString() {
 	ss << "patch_id=" << symbols_[":patch_id"] << "\n";
 	ss << "language=" << GdxsvLanguage::TextureDirectoryName() << "\n";
 	ss << "local_ip=" << lbs_net_.LocalIP() << "\n";
-	ss << "udp_port=" << udp_port_ << "\n";
+	ss << "udp_port=" << config::GdxLocalPort << "\n";
 	std::string machine_id = os_GetMachineID();
 	if (machine_id.length()) {
 		auto digest = XXH64(machine_id.c_str(), machine_id.size(), 37);
@@ -390,11 +389,11 @@ void Gdxsv::HandleRPC() {
 
 				lbs_remote_.Open(host.c_str(), port);
 				if (!udp_.Initialized()) {
-					udp_.Bind(udp_port_);
+					udp_.Bind(config::GdxLocalPort);
 				}
 				if (udp_.Initialized()) {
-					if (udp_port_ != udp_.bind_port()) {
-						config::GdxLocalPort = udp_port_ = udp_.bind_port();
+					if (config::GdxLocalPort != udp_.bind_port()) {
+						config::GdxLocalPort = udp_.bind_port();
 					}
 
 					if (config::EnableUPnP && upnp_port_ != udp_.bind_port()) {

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -73,7 +73,6 @@ class Gdxsv {
 	MiniUPnP upnp_;
 	std::future<std::string> upnp_result_;
 	int upnp_port_ = 0;
-	int udp_port_ = 0;
 
 	UdpRemote lbs_remote_ = {};
 	UdpClient udp_ = {};

--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -260,7 +260,6 @@ void GdxsvBackendRollback::OnMainUiLoop() {
 			config::GGPODelay.override(delay);
 			config::NetworkStats.override(false);
 			config::FixedFrequency.override(2);
-			config::VSync.override(false);
 			config::LimitFPS.override(false);
 			config::AudioBufferSize.override(2822);
 			config::ThreadedRendering.override(false);
@@ -438,7 +437,6 @@ void GdxsvBackendRollback::Close() {
 	config::GGPOEnable.reset();
 	config::NetworkStats.load();
 	config::FixedFrequency.load();
-	config::VSync.load();
 	config::LimitFPS.load();
 	config::AudioBufferSize.load();
 	config::ThreadedRendering.load();

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -162,7 +162,7 @@ void gdxsv_emu_settings() {
 	if (ImGui::Button(" Apply Recommended Settings ", ImVec2(0, 40))) {
 		// Frame Limit
 		config::LimitFPS = false;
-		config::VSync = false;
+		config::VSync = true;
 		config::FixedFrequency = 2;
 		// Controls
 		config::MapleMainDevices[0].set(MapleDeviceType::MDT_SegaController);
@@ -199,7 +199,7 @@ void gdxsv_emu_settings() {
 	ImGui::SameLine();
 	ShowHelpMarker(R"(Use gdxsv recommended settings:
     Frame Limit Method:
-      CPU Sleep (59.94Hz)
+      VSync + CPU Sleep (59.94Hz)
 
     Control:
       Device A: Sega Controller / Sega VMU

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -292,7 +292,9 @@ void gdxsv_emu_settings() {
 	if (upnp_future.valid() && upnp_future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
 		upnp_result = upnp_future.get();
 	}
-	if (ImGui::Button("UPnP Now") && !upnp_future.valid()) {
+
+	const auto buttonWidth = ImGui::CalcTextSize("Test The Port").x + ImGui::GetStyle().ItemSpacing.x * 2;
+	if (ImGui::Button("UPnP Now", ImVec2(buttonWidth, 0)) && !upnp_future.valid()) {
 		upnp_result = "Please wait...";
 		int port = config::GdxLocalPort;
 		upnp_future = std::async(std::launch::async, [port]() -> std::string {
@@ -311,12 +313,12 @@ void gdxsv_emu_settings() {
 	if (udp_test_future.valid() && udp_test_future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
 		udp_test_result = udp_test_future.get();
 	}
-	if (ImGui::Button("Test the port") && !udp_test_future.valid()) {
+	if (ImGui::Button("Test The Port", ImVec2(buttonWidth, 0)) && !udp_test_future.valid()) {
 		udp_test_result = "Please wait...";
 		udp_test_future = test_udp_port_connectivity(config::GdxLocalPort);
 	}
 	ImGui::SameLine();
-	ShowHelpMarker("Test if this port number can be used");
+	ShowHelpMarker("Test receiving data using this UDP port");
 	ImGui::SameLine();
 	ImGui::Text(udp_test_result.c_str());
 


### PR DESCRIPTION
The frame rate was not stable unless VSync was enabled, especially on a mac environment.
Set the recommended setting VSync=yes and then disabled the override.