### PR TITLE
Use SRTT as round_trip_time

### DIFF
--- a/core/deps/ggpo/lib/ggpo/network/udp_proto.cpp
+++ b/core/deps/ggpo/lib/ggpo/network/udp_proto.cpp
@@ -703,7 +703,8 @@ UdpProtocol::OnQualityReport(UdpMsg *msg, int len)
 bool
 UdpProtocol::OnQualityReply(UdpMsg *msg, int len)
 {
-   _round_trip_time = GGPOPlatform::GetCurrentTimeMS() - msg->u.quality_reply.pong;
+   uint32 rtt = GGPOPlatform::GetCurrentTimeMS() - msg->u.quality_reply.pong;
+   _round_trip_time = _round_trip_time == 0 ? rtt : uint32(0.5 + 0.9 * _round_trip_time + 0.1 * rtt);
    return true;
 }
 


### PR DESCRIPTION
GGPO uses RTT to estimate the frame numbers of its opponents and tries to keep in step with them.
A slight delay in the GGPO's quality report packet will have a some impact on this guess.
So instead of using RTT as is, I will use smoothed one (SRTT).
I have not verified if this will improve anything, but I don't think it will make it worse.