### PR TITLE
Replay UI/UX

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -636,6 +636,7 @@ void Emulator::runInternal()
 void Emulator::unloadGame()
 {
 	stop();
+	gdxsv_emu_reset();
 	if (state == Loaded || state == Error)
 	{
 		if (state == Loaded && config::AutoSaveState && !settings.content.path.empty())

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -51,6 +51,7 @@ void Gdxsv::Reset() {
 	udp_net_.Reset();
 	rollback_net_.Reset();
 	replay_net_.Reset();
+	netmode_ = NetMode::Offline;
 	http::init();
 
 	// Automatically add ContentPath if it is empty.

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -11,6 +11,7 @@
 #include "emulator.h"
 #include "gdx_rpc.h"
 #include "gdxsv_translation.h"
+#include "gdxsv_replay_util.h"
 #include "hw/sh4/sh4_mem.h"
 #include "imgui/imgui.h"
 #include "libs.h"
@@ -32,6 +33,8 @@ bool Gdxsv::IsOnline() const {
 }
 
 bool Gdxsv::IsSaveStateAllowed() const { return netmode_ == NetMode::Offline; }
+
+bool Gdxsv::IsReplaying() const { return netmode_ == NetMode::Replay; }
 
 bool Gdxsv::Enabled() const { return enabled_; }
 
@@ -846,6 +849,8 @@ bool Gdxsv::StartReplayFile(const char *path, int pov) {
 	}
 	return false;
 }
+
+void Gdxsv::StopReplay() { replay_net_.Close(true); }
 
 bool Gdxsv::StartRollbackTest(const char *param) {
 	rollback_net_.Reset();

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -11,7 +11,6 @@
 #include "emulator.h"
 #include "gdx_rpc.h"
 #include "gdxsv_translation.h"
-#include "gdxsv_replay_util.h"
 #include "hw/sh4/sh4_mem.h"
 #include "imgui/imgui.h"
 #include "libs.h"

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -30,6 +30,7 @@ class Gdxsv {
 	bool InGame() const;
 	bool IsOnline() const;
 	bool IsSaveStateAllowed() const;
+	bool IsReplaying() const;
 	void DisplayOSD();
 	const char* NetModeString() const;
 	void Reset();
@@ -40,6 +41,7 @@ class Gdxsv {
 	void RestoreOnlinePatch();
 	void StartPingTest();
 	bool StartReplayFile(const char* path, int pov);
+	void StopReplay();
 	bool StartRollbackTest(const char* param);
 	void WritePatch();
 	int Disk() const { return disk_; }

--- a/core/gdxsv/gdxsv_backend_replay.cpp
+++ b/core/gdxsv/gdxsv_backend_replay.cpp
@@ -65,14 +65,16 @@ bool GdxsvBackendReplay::StartBuffer(const char *buf, int size) {
 	return Start();
 }
 
+bool GdxsvBackendReplay::isReplaying() { return state_ == State::McsInBattle; }
+
 void GdxsvBackendReplay::Open() {
 	recv_buf_.assign({0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd});
 	state_ = State::McsSessionExchange;
 	ApplyPatch(true);
 }
 
-void GdxsvBackendReplay::Close() {
-	if (state_ <= State::McsWaitJoin) {
+void GdxsvBackendReplay::Close(bool by_user) {
+	if (by_user == false && state_ <= State::McsWaitJoin) {
 		return;
 	}
 

--- a/core/gdxsv/gdxsv_backend_replay.h
+++ b/core/gdxsv/gdxsv_backend_replay.h
@@ -22,8 +22,9 @@ class GdxsvBackendReplay {
 	void OnMainUiLoop();
 	bool StartFile(const char *path, int pov);
 	bool StartBuffer(const char *buf, int size);
+	bool isReplaying();
 	void Open();
-	void Close();
+	void Close(bool by_user = false);
 	u32 OnSockWrite(u32 addr, u32 size);
 	u32 OnSockRead(u32 addr, u32 size);
 	u32 OnSockPoll();

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -32,6 +32,10 @@ bool gdxsv_is_online() { return gdxsv.IsOnline(); }
 
 bool gdxsv_is_savestate_allowed() { return gdxsv.IsSaveStateAllowed(); }
 
+bool gdxsv_is_replaying() { return gdxsv.IsReplaying(); }
+
+void gdxsv_stop_replay() { gdxsv.StopReplay(); }
+
 void gdxsv_emu_flycast_init() { config::GGPOEnable = false; }
 
 void gdxsv_emu_start() {

--- a/core/gdxsv/gdxsv_emu_hooks.h
+++ b/core/gdxsv/gdxsv_emu_hooks.h
@@ -16,6 +16,10 @@ bool gdxsv_is_online();
 
 bool gdxsv_is_savestate_allowed();
 
+bool gdxsv_is_replaying();
+
+void gdxsv_stop_replay();
+
 void gdxsv_emu_flycast_init();
 
 void gdxsv_emu_start();

--- a/core/gdxsv/gdxsv_replay_util.cpp
+++ b/core/gdxsv/gdxsv_replay_util.cpp
@@ -129,6 +129,7 @@ void gdxsv_replay_select_dialog() {
 					}
 				}
 			}
+			std::sort(files.begin(), files.end(), std::greater<>());
 
 			flycast::closedir(dir);
 		}

--- a/core/gdxsv/gdxsv_replay_util.cpp
+++ b/core/gdxsv/gdxsv_replay_util.cpp
@@ -87,13 +87,14 @@ void gdxsv_replay_select_dialog() {
 
 	centerNextWindow();
 	ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
+	const float scaling = settings.display.uiScale;
 
 	ImGui::Begin("##gdxsv_emu_replay_menu", nullptr,
 				 ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize);
 
-	ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(20, 8));
+	ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(20, 8) * scaling);
 	ImGui::AlignTextToFramePadding();
-	ImGui::Indent(10 * settings.display.uiScale);
+	ImGui::Indent(10 * scaling);
 
 	ImGui::SameLine();
 	if (ImGui::Button("Close")) {
@@ -133,10 +134,10 @@ void gdxsv_replay_select_dialog() {
 		}
 	}
 
-	ImGui::Unindent(10 * settings.display.uiScale);
-	ImGui::PopStyleVar();
+	ImGui::Unindent(10 * scaling);
+	ImGui::PopStyleVar(); //ImGuiStyleVar_FramePadding
 
-	ImGui::BeginChild(ImGui::GetID("gdxsv_replay_file_list"), ImVec2(330, 0), true, ImGuiWindowFlags_DragScrolling);
+	ImGui::BeginChild(ImGui::GetID("gdxsv_replay_file_list"), ImVec2(330, 0) * scaling, true, ImGuiWindowFlags_DragScrolling);
 	{
 		if (files.empty()) {
 			ImGui::Text("(No replay found)");
@@ -201,6 +202,8 @@ void gdxsv_replay_select_dialog() {
 			}
 
 			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(.2f, .1f, .6f, 1));
+			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 2.0f * scaling);
+			
 			for (int i : renpo_index) {
 				if (i != renpo_index.front()) ImGui::SameLine();
 				ImGui::BeginChild(
@@ -225,6 +228,8 @@ void gdxsv_replay_select_dialog() {
 				ImGui::EndChild();
 			}
 			ImGui::PopStyleColor();
+			
+			ImGui::PopStyleVar(); //ImGuiStyleVar_ChildBorderSize
 
 			auto povString = [](int i) -> std::string {
 				if (battle_log.users_size() <= i) return "";

--- a/core/gdxsv/gdxsv_replay_util.cpp
+++ b/core/gdxsv/gdxsv_replay_util.cpp
@@ -23,7 +23,7 @@ static std::vector<std::pair<std::string, uint64_t>> files;
 static std::string selected_replay_file;
 static std::string battle_log_file_name;
 static proto::BattleLogFile battle_log;
-static int pov_index = 0;
+static int pov_index = -1;
 
 static bool download_replay_savestate(int disk, const std::string& save_path) {
 	std::string content_type;
@@ -171,7 +171,7 @@ void gdxsv_replay_select_dialog() {
 					battle_log.ParseFromFileDescriptor(fileno(fp));
 					std::fclose(fp);
 				}
-				pov_index = 0;
+				pov_index = -1;
 			}
 
 			const bool playable = "dc" + std::to_string(gdxsv.Disk()) == battle_log.game_disk();
@@ -200,12 +200,23 @@ void gdxsv_replay_select_dialog() {
 				if (battle_log.users(i).team() == 1) renpo_index.push_back(i);
 				if (battle_log.users(i).team() == 2) zeon_index.push_back(i);
 			}
+			int user_index = 0;
 
-			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(.2f, .1f, .6f, 1));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 2.0f * scaling);
 			
+			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(.42f, .79f, .99f, 1));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(.055f, .122f, .227f, .3f));
 			for (int i : renpo_index) {
 				if (i != renpo_index.front()) ImGui::SameLine();
+				auto pos = ImGui::GetCursorPos();
+				if (ImGui::Selectable(("##pov_" + std::to_string(user_index)).c_str(), (pov_index == user_index), 0, ScaledVec2(180, 80))) {
+					if (pov_index == user_index) {
+						pov_index = -1;
+					} else {
+						pov_index = user_index;
+					}
+				}
+				ImGui::SetCursorPos(ImVec2(pos.x, pos.y));
 				ImGui::BeginChild(
 					ImGui::GetID(("gdxsv_replay_file_detail_renpo_" + std::to_string(i)).c_str()), ScaledVec2(180, 80), true,
 					ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoNavFocus);
@@ -213,12 +224,24 @@ void gdxsv_replay_select_dialog() {
 				textCentered("HN: " + battle_log.users(i).user_name());
 				textCentered("PN: " + battle_log.users(i).pilot_name());
 				ImGui::EndChild();
+				user_index++;
 			}
 			ImGui::PopStyleColor();
+			ImGui::PopStyleColor();
 
-			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(.6f, .1f, .2f, 1));
+			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(.97f, .23f, .35f, 1));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(.196f, .07f, .05f, .3f));
 			for (int i : zeon_index) {
 				if (i != zeon_index.front()) ImGui::SameLine();
+				auto pos = ImGui::GetCursorPos();
+				if (ImGui::Selectable(("##pov_" + std::to_string(user_index)).c_str(), (pov_index == user_index), 0, ScaledVec2(180, 80))) {
+					if (pov_index == user_index) {
+						pov_index = -1;
+					} else {
+						pov_index = user_index;
+					}
+				}
+				ImGui::SetCursorPos(ImVec2(pos.x, pos.y));
 				ImGui::BeginChild(
 					ImGui::GetID(("gdxsv_replay_file_detail_zeon_" + std::to_string(i)).c_str()), ScaledVec2(180, 80), true,
 					ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoNavFocus);
@@ -226,34 +249,17 @@ void gdxsv_replay_select_dialog() {
 				textCentered("HN: " + battle_log.users(i).user_name());
 				textCentered("PN: " + battle_log.users(i).pilot_name());
 				ImGui::EndChild();
+				user_index++;
 			}
+			ImGui::PopStyleColor();
 			ImGui::PopStyleColor();
 			
 			ImGui::PopStyleVar(); //ImGuiStyleVar_ChildBorderSize
 
-			auto povString = [](int i) -> std::string {
-				if (battle_log.users_size() <= i) return "";
-				const auto& u = battle_log.users(i);
-				char buf[128] = {};
-				snprintf(buf, sizeof(buf), "%dP\tID: %s\tHN: %s\tPN: %s", i + 1, u.user_id().c_str(), u.user_name().c_str(),
-						 u.pilot_name().c_str());
-				return buf;
-			};
+			bool pov_selected = (pov_index == -1);
+			DisabledScope scope(pov_selected);
 
-			if (ImGui::BeginCombo("POV", povString(pov_index).c_str())) {
-				for (int i = 0; i < battle_log.users_size(); i++) {
-					bool selected = pov_index == i;
-					if (ImGui::Selectable(povString(i).c_str(), selected, 0, ImVec2(0, 0))) {
-						pov_index = i;
-					}
-					if (selected) {
-						ImGui::SetItemDefaultFocus();
-					}
-				}
-				ImGui::EndCombo();
-			}
-
-			if (ImGui::ButtonEx("Play", ScaledVec2(240, 50), playable ? 0 : ImGuiButtonFlags_Disabled)) {
+			if (ImGui::ButtonEx(pov_selected ? "Select a player" : "Replay", ScaledVec2(240, 50), playable ? 0 : ImGuiButtonFlags_Disabled) && !scope.isDisabled()) {
 				gdxsv_start_replay(replay_dir + "/" + selected_replay_file, pov_index);
 			}
 		}

--- a/core/gdxsv/gdxsv_replay_util.cpp
+++ b/core/gdxsv/gdxsv_replay_util.cpp
@@ -75,6 +75,8 @@ void gdxsv_end_replay() {
 	dc_loadstate(90);
 	settings.input.fastForwardMode = false;
 
+	emu.start();
+	emu.render();
 	if (!selected_replay_file.empty()) {
 		gui_state = GuiState::GdxsvReplay;
 	}

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -616,17 +616,32 @@ static void gui_display_commands()
 	}
 	ImGui::Columns(1, nullptr, false);
 
+	// GdxReplay
+	if (gdxsv_enabled())
+	{
+		DisabledScope scope(gdxsv_is_online());
+		
+		if (!gdxsv_is_replaying() && ImGui::Button("Replays", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)) && !scope.isDisabled())
+		{
+			gui_state = GuiState::GdxsvReplay;
+		}
+		if (gdxsv_is_online() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+		{
+			ImGui::SetTooltip("Please disconnect from the Gdxsv server first.");
+		}
+		
+		if (gdxsv_is_replaying() && ImGui::Button("Stop Replay", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)))
+		{
+			gui_state = GuiState::Closed;
+			gdxsv_stop_replay();
+		}
+	}
+	
 	// Exit
 	if (ImGui::Button("Exit", ScaledVec2(300, 50)
 			+ ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)))
 	{
 		gui_stop_game();
-	}
-
-	// GdxReplay
-	if (gdxsv_enabled() && !gdxsv_is_online() && ImGui::Button("Replays", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)))
-	{
-		gui_state = GuiState::GdxsvReplay;
 	}
 
 	ImGui::End();


### PR DESCRIPTION
### 1. Put `Replays` button above `Exit`, always show `Replays` button + add tooltip
<img width="289" alt="image" src="https://user-images.githubusercontent.com/602245/236647102-c6649265-64cf-4e26-9cd0-4cfe6c44303f.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/602245/236648061-860a674c-a57b-456e-86fe-4cb5fdf189f4.png">


### 2. Fix Load/Save State Button disabled after replay

current UX problem (v1.3.1):

![May-07-2023 05-27-36](https://user-images.githubusercontent.com/602245/236647242-8ebabee6-b6bd-4f8f-841e-46e5f5249c16.gif)

### 3. Allow user to stop replaying.

![May-07-2023 06-22-41](https://user-images.githubusercontent.com/602245/236648728-2e900f3b-58bc-449c-a058-8e87f8f9532a.gif)


### 4. After finishing playback, render a frame of the original state `90`, to create the sense of state changes.

v1.3.1:
![May-07-2023 05-43-37](https://user-images.githubusercontent.com/602245/236647779-498a0f58-9956-4c4c-a1ac-cd63de8eb5d1.gif)

this PR:
![May-07-2023 05-45-59](https://user-images.githubusercontent.com/602245/236647787-de2ea5c1-4cd0-4b4e-9a19-2cf368e451ca.gif)


### 5. Fix UI scaling + stroke width in retina monitor

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/602245/236647375-5775ec4f-d435-4d3f-aae0-4342e921ec80.png">

### 6. Improve POV selection
![May-07-2023 06-24-56](https://user-images.githubusercontent.com/602245/236648775-b0efba7f-888a-475b-b3b3-405eab80fb2a.gif)


### 7. Replay sorting (newest on top)
`readdir()` does not sort in macOS:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/602245/236648677-ce04f737-e138-4a9d-ac44-9fd4ed5194d8.png">

 