### PR TITLE
Fix blackout when game end with ThreadedRendering

### DIFF
--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -934,8 +934,10 @@ void Emulator::start()
 						startTime = sh4_sched_now64();
 						renderTimeout = false;
 						runInternal();
-						if (!ggpo::nextFrame())
-							break;
+						// NOTE: modified for gdxsv
+						// to keep running emulator thread if ggpo stopped.
+						if (ggpo::active()) ggpo::nextFrame();
+						// if (!ggpo::nextFrame()) break;
 					}
 					TermAudio();
 				} catch (...) {


### PR DESCRIPTION
Continue thread even if ggpo stop.
But at the same time there is a problem that the thread will not stop when there is nothing to render.