### PR TITLE
Fix macOS deadlock during quit app

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -124,8 +124,6 @@ void Gdxsv::Reset() {
 	NOTICE_LOG(COMMON, "gdxsv disk:%d server:%s loginkey:%s udp_port:%d", (int)disk_, server_.c_str(), loginkey_.c_str(),
 			   config::GdxLocalPort.get());
 
-	FetchPublicIP();
-
 	lbs_net_.lbs_packet_filter([this](const LbsMessage &lbs_msg) -> bool {
 		if (netmode_ != NetMode::Lbs) {
 			if (lbs_net_.IsConnected()) {

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -50,6 +50,7 @@ void gdxsv_emu_start() {
 			dc_loadstate(99);
 		} else {
 			gdxsv.StartPingTest();
+			gdxsv.FetchPublicIP();
 		}
 	}
 }


### PR DESCRIPTION
When quitting the app, calling `gdxsv.Reset()` would fetch IP addresses again and deadlock