### PR TITLE
Prevent SDL Window blocking main thread during battle

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -237,19 +237,24 @@ void Gdxsv::HookMainUiLoop() {
 	if (InGame()) {
 		settings.input.fastForwardMode = false;
 #if defined(USE_SDL)
-		if (!prevent_window_blocking_)
+		if (!monitor_system_event_)
 		{
-			SDL_Event event;
-			event.type = SDL_GDXSV_PREVENT_WINDOW_BLOCKING;
-			SDL_PushEvent(&event);
-			prevent_window_blocking_ = true;
+			SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+			monitor_system_event_ = true;
 		}
 	} else {
+		if (monitor_system_event_)
+		{
+			SDL_EventState(SDL_SYSWMEVENT, SDL_DISABLE);
+			monitor_system_event_ = false;
+			prevent_window_blocking_counter_ = 0;
+		}
 		if (prevent_window_blocking_)
 		{
 			SDL_Event event;
 			event.type = SDL_GDXSV_RESUME_WINDOW_BLOCKING;
 			SDL_PushEvent(&event);
+			prevent_window_blocking_ = false;
 		}
 #endif
 	}
@@ -266,6 +271,21 @@ void Gdxsv::HookMainUiLoop() {
 		if (netmode_ == NetMode::Lbs && lbs_net_.IsConnected()) {
 			// Prevent disconnection from lobby server
 			lbs_net_.OnSockPoll();
+		}
+	}
+}
+
+void Gdxsv::WindowBlocked()
+{
+	if (gdxsv.InGame())
+	{
+		prevent_window_blocking_counter_++;
+		if (prevent_window_blocking_counter_ >= 10)
+		{
+			SDL_Event event;
+			event.type = SDL_GDXSV_PREVENT_WINDOW_BLOCKING;
+			SDL_PushEvent(&event);
+			prevent_window_blocking_ = true;
 		}
 	}
 }

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -22,6 +22,10 @@
 #include "rend/boxart/http_client.h"
 #include "rend/gui.h"
 #include "version.h"
+#include "gdxsv_emu_hooks.h"
+#if defined(USE_SDL)
+#include "sdl/sdl.h"
+#endif
 
 bool encode_zlib_deflate(const char *data, int len, std::vector<u8> &out) {
 	z_stream z{};
@@ -232,6 +236,22 @@ void Gdxsv::HookMainUiLoop() {
 
 	if (InGame()) {
 		settings.input.fastForwardMode = false;
+#if defined(USE_SDL)
+		if (!prevent_window_blocking_)
+		{
+			SDL_Event event;
+			event.type = SDL_GDXSV_PREVENT_WINDOW_BLOCKING;
+			SDL_PushEvent(&event);
+			prevent_window_blocking_ = true;
+		}
+	} else {
+		if (prevent_window_blocking_)
+		{
+			SDL_Event event;
+			event.type = SDL_GDXSV_RESUME_WINDOW_BLOCKING;
+			SDL_PushEvent(&event);
+		}
+#endif
 	}
 
 	if (netmode_ == NetMode::McsRollback) {

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -37,6 +37,7 @@ class Gdxsv {
 	bool HookOpenMenu();
 	void HookVBlank();
 	void HookMainUiLoop();
+	void WindowBlocked();
 	void HandleRPC();
 	void RestoreOnlinePatch();
 	void StartPingTest();
@@ -84,7 +85,10 @@ class Gdxsv {
 	GdxsvBackendUdp udp_net_;
 	GdxsvBackendReplay replay_net_;
 	GdxsvBackendRollback rollback_net_;
+	
+	bool monitor_system_event_ = false;
 	bool prevent_window_blocking_ = false;
+	int prevent_window_blocking_counter_ = 0;
 };
 
 extern Gdxsv gdxsv;

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -84,6 +84,7 @@ class Gdxsv {
 	GdxsvBackendUdp udp_net_;
 	GdxsvBackendReplay replay_net_;
 	GdxsvBackendRollback rollback_net_;
+	bool prevent_window_blocking_ = false;
 };
 
 extern Gdxsv gdxsv;

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -103,6 +103,8 @@ bool gdxsv_emu_menu_open() {
 	return true;
 }
 
+void gdxsv_window_blocked() { gdxsv.WindowBlocked(); }
+
 bool gdxsv_widescreen_hack_enabled() { return gdxsv.Enabled() && config::WidescreenGameHacks; }
 
 static void gui_header(const char* title) {

--- a/core/gdxsv/gdxsv_emu_hooks.h
+++ b/core/gdxsv/gdxsv_emu_hooks.h
@@ -52,5 +52,7 @@ void gdxsv_crash_append_log(FILE* f);
 
 void gdxsv_crash_append_tag(const std::string& logfile, std::vector<http::PostField>& post_fields);
 
+void gdxsv_window_blocked();
+
 const uint32_t SDL_GDXSV_PREVENT_WINDOW_BLOCKING = 0x9000;
 const uint32_t SDL_GDXSV_RESUME_WINDOW_BLOCKING = 0x9001;

--- a/core/gdxsv/gdxsv_emu_hooks.h
+++ b/core/gdxsv/gdxsv_emu_hooks.h
@@ -51,3 +51,6 @@ void gdxsv_gui_display_osd();
 void gdxsv_crash_append_log(FILE* f);
 
 void gdxsv_crash_append_tag(const std::string& logfile, std::vector<http::PostField>& post_fields);
+
+const uint32_t SDL_GDXSV_PREVENT_WINDOW_BLOCKING = 0x9000;
+const uint32_t SDL_GDXSV_RESUME_WINDOW_BLOCKING = 0x9001;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -18,6 +18,7 @@
 #include "emulator.h"
 #include "stdclass.h"
 #include "imgui/imgui.h"
+#include "gdxsv/gdxsv_emu_hooks.h"
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(__SWITCH__)
 #include "linux-dist/icon.h"
 #endif
@@ -245,6 +246,18 @@ void input_sdl_handle()
 	{
 		switch (event.type)
 		{
+			case SDL_GDXSV_PREVENT_WINDOW_BLOCKING:
+				SDL_SetWindowResizable(window, SDL_FALSE);
+#ifndef TARGET_MAC
+				SDL_SetWindowBordered(window, SDL_FALSE);
+#endif
+				break;
+			case SDL_GDXSV_RESUME_WINDOW_BLOCKING:
+				SDL_SetWindowResizable(window, SDL_TRUE);
+#ifndef TARGET_MAC
+				SDL_SetWindowBordered(window, SDL_TRUE);
+#endif
+				break;
 			case SDL_QUIT:
 				dc_exit();
 				break;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -258,6 +258,7 @@ void input_sdl_handle()
 				SDL_SetWindowBordered(window, SDL_TRUE);
 #endif
 				break;
+
 			case SDL_QUIT:
 				dc_exit();
 				break;
@@ -300,12 +301,24 @@ void input_sdl_handle()
 				gui_keyboard_inputUTF8(event.text.text);
 				break;
 
+#ifdef _WIN32
+			case SDL_SYSWMEVENT:
+				if (event.syswm.msg->msg.win.msg == WM_CAPTURECHANGED)
+				{
+					gdxsv_window_blocked();
+				}
+				break;
+
+#endif
 			case SDL_WINDOWEVENT:
 				if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED
 						|| event.window.event == SDL_WINDOWEVENT_RESTORED
 						|| event.window.event == SDL_WINDOWEVENT_MINIMIZED
 						|| event.window.event == SDL_WINDOWEVENT_MAXIMIZED)
 				{
+#ifdef TARGET_MAC
+					gdxsv_window_blocked();
+#endif
 #ifdef USE_VULKAN
 					if (windowFlags & SDL_WINDOW_VULKAN)
 						SDL_Vulkan_GetDrawableSize(window, &settings.display.width, &settings.display.height);


### PR DESCRIPTION
During battle, make the window not resizable in macOS, and not resizable + draggable in Windows. 

Long standing issue: https://github.com/libsdl-org/SDL/issues/1059
> one person decides to drag or resize their window, and the whole session dies, pissing off all of the players trying to play

> One player (not even the host) was dragging their window in a match I had and everyone was confused as to why everyone was suddenly lagging