### PR TITLE
Gdxsv fast rollback opt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2087,6 +2087,8 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/gdxsv_network.cpp
 		core/gdxsv/gdxsv_network.h
 		core/gdxsv/gdxsv_patch.inc
+		core/gdxsv/gdxsv_prof.h
+		core/gdxsv/gdxsv_prof.cpp
 		core/gdxsv/gdxsv_emu_hooks.cpp
 		core/gdxsv/gdxsv_emu_hooks.h
 		core/gdxsv/gdxsv_update.h

--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -143,6 +143,9 @@ Option<int> GdxLocalPort("LocalPort", 0, "gdxsv");
 Option<int> GdxMinDelay("MinDelay", 2, "gdxsv");
 Option<bool> GdxSaveReplay("SaveReplay", true, "gdxsv");
 Option<bool> GdxUploadReplay("UploadReplay", true, "gdxsv");
+Option<bool> GdxSkipRenderingHack("SkipRenderingHack", true, "gdxsv");
+Option<bool> GdxSlowIdleLoopHack("SlowIdleLoopHack", true, "gdxsv");
+
 Option<bool> GdxReplayHideName("ReplayHideName", false, "gdxsv");
 Option<bool> GdxReplayShowAllyHP("ReplayShowAllyHP", true, "gdxsv");
 Option<bool> GdxReplayKeyDisplay("ReplayKeyDisplay", true, "gdxsv");

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -501,6 +501,8 @@ extern Option<int> GdxLocalPort;
 extern Option<int> GdxMinDelay;
 extern Option<bool> GdxSaveReplay;
 extern Option<bool> GdxUploadReplay;
+extern Option<bool> GdxSkipRenderingHack;
+extern Option<bool> GdxSlowIdleLoopHack;
 extern Option<bool> GdxReplayHideName;
 extern Option<bool> GdxReplayShowAllyHP;
 extern Option<bool> GdxReplayKeyDisplay;

--- a/core/emulator.cpp
+++ b/core/emulator.cpp
@@ -886,6 +886,7 @@ void Emulator::run()
 	renderTimeout = false;
 	try {
 		runInternal();
+		gdxsv_emu_next_frame();
 		if (ggpo::active())
 			ggpo::nextFrame();
 	} catch (...) {
@@ -934,10 +935,8 @@ void Emulator::start()
 						startTime = sh4_sched_now64();
 						renderTimeout = false;
 						runInternal();
-						// NOTE: modified for gdxsv
-						// to keep running emulator thread if ggpo stopped.
+						gdxsv_emu_next_frame();
 						if (ggpo::active()) ggpo::nextFrame();
-						// if (!ggpo::nextFrame()) break;
 					}
 					TermAudio();
 				} catch (...) {
@@ -1012,8 +1011,10 @@ void Emulator::vblank()
 	if (sh4_sched_now64() - startTime <= 10000000)
 		return;
 	renderTimeout = true;
-	if (ggpo::active())
+	if (ggpo::active()) {
+		gdxsv_emu_end_frame();
 		ggpo::endOfFrame();
+	}
 	else if (!config::ThreadedRendering)
 		sh4_cpu.Stop();
 }

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -12,7 +12,7 @@
 #include "gdx_rpc.h"
 #include "gdxsv_key_display.h"
 #include "gdxsv_translation.h"
-#include "hw/sh4/dyna/blockmanager.h"
+#include "gdxsv_prof.h"
 #include "imgui/imgui.h"
 #include "libs.h"
 #include "log/InMemoryListener.h"
@@ -87,6 +87,7 @@ void Gdxsv::Reset() {
 	replay_net_.Reset();
 	netmode_ = NetMode::Offline;
 	http::init();
+	settings.gdxsv.disk = 0;
 
 	// Automatically add ContentPath if it is empty.
 	if (config::ContentPath.get().empty()) {
@@ -115,6 +116,7 @@ void Gdxsv::Reset() {
 	std::string disk_num(ip_meta.disk_num, 1);
 	if (disk_num == "1") disk_ = 1;
 	if (disk_num == "2") disk_ = 2;
+	settings.gdxsv.disk = disk_;
 
 	maxrebattle_ = 5;
 
@@ -234,10 +236,22 @@ void Gdxsv::HookVBlank() {
 		// Don't edit memory at vsync if ggpo::active
 		WritePatch();
 	}
+}
+
+void Gdxsv::HookEndOfFrame()
+{
 	if (netmode_ == NetMode::Replay) {
-		gdxsv.replay_net_.OnVBlank();
+		gdxsv.replay_net_.OnEndOfFrame();
 	}
 }
+
+void Gdxsv::HookNextFrame()
+{
+	if (netmode_ == NetMode::Replay) {
+		gdxsv.replay_net_.OnNextFrame();
+	}
+}
+
 
 void Gdxsv::HookMainUiLoop() {
 	if (!enabled_) return;

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -11,8 +11,8 @@
 #include "emulator.h"
 #include "gdx_rpc.h"
 #include "gdxsv_key_display.h"
-#include "gdxsv_translation.h"
 #include "gdxsv_prof.h"
+#include "gdxsv_translation.h"
 #include "imgui/imgui.h"
 #include "libs.h"
 #include "log/InMemoryListener.h"
@@ -238,20 +238,17 @@ void Gdxsv::HookVBlank() {
 	}
 }
 
-void Gdxsv::HookEndOfFrame()
-{
+void Gdxsv::HookEndOfFrame() {
 	if (netmode_ == NetMode::Replay) {
 		gdxsv.replay_net_.OnEndOfFrame();
 	}
 }
 
-void Gdxsv::HookNextFrame()
-{
+void Gdxsv::HookNextFrame() {
 	if (netmode_ == NetMode::Replay) {
 		gdxsv.replay_net_.OnNextFrame();
 	}
 }
-
 
 void Gdxsv::HookMainUiLoop() {
 	if (!enabled_) return;

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -38,6 +38,8 @@ class Gdxsv {
 	bool HookOpenMenu();
 	void HookVBlank();
 	void HookMainUiLoop();
+	void HookEndOfFrame();
+	void HookNextFrame();
 	void HandleRPC();
 	void RestoreOnlinePatch();
 	void StartPingTest();
@@ -51,7 +53,7 @@ class Gdxsv {
 	std::string UserId() const { return user_id_; }
 	MiniUPnP& UPnP() { return upnp_; }
 
-   private:
+private:
 	void AddPortMapping();
 	static std::string GenerateLoginKey();
 	std::vector<u8> GeneratePlatformInfoPacket();

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -53,7 +53,7 @@ class Gdxsv {
 	std::string UserId() const { return user_id_; }
 	MiniUPnP& UPnP() { return upnp_; }
 
-private:
+   private:
 	void AddPortMapping();
 	static std::string GenerateLoginKey();
 	std::vector<u8> GeneratePlatformInfoPacket();

--- a/core/gdxsv/gdxsv_backend_replay.cpp
+++ b/core/gdxsv/gdxsv_backend_replay.cpp
@@ -7,12 +7,15 @@
 #include "emulator.h"
 #include "gdx_rpc.h"
 #include "gdxsv.h"
+#include "gdxsv_prof.h"
 #include "gdxsv_replay_util.h"
 #include "input/gamepad_device.h"
 #include "libs.h"
 #include "rend/gui.h"
 #include "rend/gui_util.h"
 #include "sdl/sdl.h"
+
+using namespace std::chrono;
 
 void GdxsvBackendReplay::Reset() {
 	state_ = State::None;
@@ -45,26 +48,30 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 	}
 	*/
 
+	if (state_ == State::End) {
+		gdxsv_save_state.Reset();
+		gdxsv_end_replay();
+		return;
+	}
+
 	if (state_ == State::Start) {
 		kcode[0] = ~0x0004u;
-		ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameForward, 60});
+		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameForward, 60 });
 	}
 
 	if (state_ == State::McsInBattle) {
 		const int disk = gdxsv.Disk();
 		const int COM_R_No0 = disk == 1 ? 0x0c2f6639 : 0x0c391d79;
-		if (gdxsv_ReadMem8(COM_R_No0) == 4 && gdxsv_ReadMem8(COM_R_No0 + 5) == 1) {
-			ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing, 60});
-		}
 		if (gdxsv_ReadMem8(COM_R_No0) == 4 && (gdxsv_ReadMem8(COM_R_No0 + 5) == 3 || gdxsv_ReadMem8(COM_R_No0 + 5) == 4)) {
+			// re-battle end
 			Stop();
 		}
-	}
-
-	if (state_ == State::End) {
-		gdxsv_save_state.Reset();
-		gdxsv_end_replay();
-		return;
+		else if (gdxsv_ReadMem8(COM_R_No0) == 4 && gdxsv_ReadMem8(COM_R_No0 + 5) != 0) {
+			// not game scene
+			if (ctrl_commands_.empty()) {
+				ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
+			}
+		}
 	}
 
 	if (State::LbsStartBattleFlow <= state_ && !pause_menu_opend_) {
@@ -93,7 +100,8 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 			if (~input.kcode & DC_BTN_X) {
 				if (~pressed_kcode & (BTN_TRIGGER_RIGHT | DC_BTN_Z)) CtrlSomeFrameForward();
 				if (~pressed_kcode & (BTN_TRIGGER_LEFT | DC_BTN_C)) CtrlSomeFrameBackward();
-			} else {
+			}
+			else {
 				if (~pressed_kcode & DC_BTN_B) CtrlSetSpeed(0), CtrlTogglePause();
 				if (~pressed_kcode & DC_BTN_A) CtrlSetSpeed(0), CtrlStepFrame();
 				if (~pressed_kcode & (BTN_TRIGGER_RIGHT | DC_BTN_Z)) CtrlSetSpeed(0), CtrlNextRound();
@@ -109,15 +117,27 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 	}
 }
 
-void GdxsvBackendReplay::OnVBlank() {
+void GdxsvBackendReplay::OnEndOfFrame() {
+	end_of_frame_ = true;
+	sh4_cpu.Stop();
+}
+
+void GdxsvBackendReplay::OnNextFrame() {
+	if (!end_of_frame_) return;
+	if (seeking_) return;
+
 	constexpr int save_interval = 180;
 	auto in_briefing = [disk = gdxsv.Disk()]() -> bool {
 		return disk == 1 ? gdxsv_ReadMem8(0x0c336254) == 2 && gdxsv_ReadMem8(0x0c336255) == 5
-						 : gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 5;
+			: gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 5;
 	};
 	auto in_game = [disk = gdxsv.Disk()]() -> bool {
 		return disk == 1 ? gdxsv_ReadMem8(0x0c336254) == 2 && gdxsv_ReadMem8(0x0c336255) == 7
-						 : gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 7;
+			: gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 7;
+	};
+
+	auto need_cancel = [&]() -> bool {
+		return ctrl_commands_.contains(ReplayCtrlCommand::SaveFirstFrame) || state_ == State::End;
 	};
 
 	gdxsv.key_display_.enabled(config::GdxReplayKeyDisplay && in_game());
@@ -127,9 +147,9 @@ void GdxsvBackendReplay::OnVBlank() {
 		gdxsv_save_state.SaveState(key_msg_count_);
 	}
 
-	while (!ctrl_commands_.empty()) {
+	ReplayCtrlCommand ctrl{};
+	while (ctrl_commands_.try_get_front(ctrl)) {
 		constexpr int duration = 1000;
-		auto &ctrl = ctrl_commands_.front();
 
 		if (ctrl.cmd == ReplayCtrlCommand::TogglePauseMenu) {
 			pause_menu_opend_ = !pause_menu_opend_;
@@ -139,6 +159,7 @@ void GdxsvBackendReplay::OnVBlank() {
 
 		if (ctrl.cmd == ReplayCtrlCommand::SaveFirstFrame) {
 			if (!recv_buf_.empty()) break;
+			NOTICE_LOG(COMMON, "SaveFirstFrame saved");
 			gdxsv_save_state.Clear();
 			gdxsv_save_state.SaveState(key_msg_count_);
 			ctrl_commands_.pop_front();
@@ -180,47 +201,69 @@ void GdxsvBackendReplay::OnVBlank() {
 		}
 
 		if (ctrl.cmd == ReplayCtrlCommand::SomeFrameForward) {
-			static std::chrono::high_resolution_clock::time_point t0;
-			const int skip_frames = ctrl.arg1 != 0 ? ctrl.arg1 : 300;
-			if (ctrl.var1 == 0) {
-				t0 = std::chrono::high_resolution_clock::now();
-				ctrl.var1 = 1;
-				ctrl.var2 = skip_frames;
+			gui_display_notification(">>", duration);
+			const int skip_frames = 1 <= ctrl.arg1 ? ctrl.arg1 : save_interval;
+			int skipped_frame;
+			auto t0 = high_resolution_clock::now();
+
+			const int prev_key_msg_count = key_msg_count_;
+			for (skipped_frame = 0; skipped_frame < skip_frames; skipped_frame++) {
 				settings.aica.muteAudio = true;
+				settings.gdxsv.skipRenderingHack = config::GdxSkipRenderingHack && skipped_frame + 1 < skip_frames;
 				rend_enable_renderer(false);
-				gui_display_notification(">>", duration);
-			}
-			if (ctrl.var2-- == 0) {
+				seeking_ = true;
+				emu.run();
+				// Regular save state
+				if ((in_briefing() || in_game()) && gdxsv_save_state.LastSavedFrame() + save_interval <= key_msg_count_ && recv_buf_.empty()) {
+					gdxsv_save_state.SaveState(key_msg_count_);
+				}
 				settings.aica.muteAudio = false;
+				settings.gdxsv.skipRenderingHack = false;
 				rend_enable_renderer(true);
-				auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - t0).count();
-				NOTICE_LOG(COMMON, "SomeFrameForward skipped %d[fr] in %ld[ms] (%.2f[ms/fr])", skip_frames, ms, (float)ms / skip_frames);
-				ctrl_commands_.pop_front();
-			} else {
-				break;
+				seeking_ = false;
+				end_of_frame_ = false;
+				if (need_cancel()) break;
 			}
+
+			if (0 < skipped_frame) {
+				const auto ms = duration_cast<milliseconds>(high_resolution_clock::now() - t0).count();
+				NOTICE_LOG(COMMON, "SomeFrameForward skipped %d[fr] in %ld[ms] (%.2f[ms/fr]) %d->%d(%d keys)", skipped_frame, ms, (float)ms / skipped_frame, prev_key_msg_count, key_msg_count_, key_msg_count_ - prev_key_msg_count);
+				char buf[256];
+				sprintf_s(buf, "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
+				gui_display_notification(buf, duration);
+			}
+			ctrl_commands_.pop_front();
 		}
 
 		if (ctrl.cmd == ReplayCtrlCommand::SeekToBriefing) {
-			ctrl.var1++;
-			if (ctrl.var1 == 1) {
-				if (in_briefing() || in_game()) {
-					ctrl_commands_.pop_front();
-				} else {
-					ctrl_pause_ = false;
-					gui_display_notification("Loading...", duration);
-				}
-			} else if (ctrl.var1 == 3) {
+			auto t0 = high_resolution_clock::now();
+			int skipped_frame = 0;
+
+			while (!(in_briefing() || in_game() || need_cancel())) {
 				settings.aica.muteAudio = true;
+				settings.gdxsv.skipRenderingHack = config::GdxSkipRenderingHack;
 				rend_enable_renderer(false);
-			} else if (in_briefing() || in_game()) {
+				seeking_ = true;
+				emu.run();
 				settings.aica.muteAudio = false;
+				settings.gdxsv.skipRenderingHack = false;
 				rend_enable_renderer(true);
-				gdxsv.key_display_.Clear();
-				ctrl_commands_.pop_front();
-			} else {
-				break;
+				seeking_ = false;
+				end_of_frame_ = false;
+				skipped_frame++;
+				if (need_cancel()) break;
 			}
+
+			if (0 < skipped_frame) {
+				const auto ms = duration_cast<milliseconds>(high_resolution_clock::now() - t0).count();
+				NOTICE_LOG(COMMON, "SeekToBriefing skipped %d[fr] in %ld[ms] (%.2f[ms/fr])", skipped_frame, ms, (float)ms / skipped_frame);
+				char buf[256];
+				sprintf_s(buf, "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
+				gui_display_notification(buf, duration);
+			}
+
+			ctrl_commands_.pop_front();
+			gdxsv.key_display_.Clear();
 		}
 
 		if (ctrl.cmd == ReplayCtrlCommand::SomeFrameBackward) {
@@ -235,9 +278,6 @@ void GdxsvBackendReplay::OnVBlank() {
 						KillTex = true;
 					}
 					gui_display_notification("<<", duration);
-					NOTICE_LOG(COMMON, "LoadState ok");
-				} else {
-					NOTICE_LOG(COMMON, "LoadState failure");
 				}
 			}
 			ctrl_commands_.pop_front();
@@ -287,7 +327,7 @@ void GdxsvBackendReplay::OnVBlank() {
 				gdxsv.maxlag_ = 1;	// for StartMsg
 				NOTICE_LOG(COMMON, "ctrl_change_round_:%d key_msg_count_:%d", round, key_msg_count_);
 				NOTICE_LOG(COMMON, "start_msg_randoms_size:%d", log_file_.start_msg_randoms_size());
-				ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing});
+				ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
 			}
 
 			ctrl_commands_.pop_front();
@@ -300,7 +340,7 @@ bool GdxsvBackendReplay::OnOpenMenu() {
 		return false;
 	}
 
-	ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::TogglePauseMenu});
+	ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::TogglePauseMenu });
 
 	return false;
 }
@@ -311,11 +351,11 @@ void GdxsvBackendReplay::DisplayOSD() {
 	}
 }
 
-bool GdxsvBackendReplay::StartFile(const char *path, int pov) {
+bool GdxsvBackendReplay::StartFile(const char* path, int pov) {
 #ifdef NOWIDE_CONFIG_H_INCLUDED
-	FILE *fp = nowide::fopen(path, "rb");
+	FILE* fp = nowide::fopen(path, "rb");
 #else
-	FILE *fp = fopen(path, "rb");
+	FILE* fp = fopen(path, "rb");
 #endif
 	if (fp == nullptr) {
 		NOTICE_LOG(COMMON, "fopen failed path:%s", path);
@@ -338,7 +378,7 @@ bool GdxsvBackendReplay::StartFile(const char *path, int pov) {
 	return Start();
 }
 
-bool GdxsvBackendReplay::StartBuffer(const std::vector<u8> &buf, int pov) {
+bool GdxsvBackendReplay::StartBuffer(const std::vector<u8>& buf, int pov) {
 	bool ok = log_file_.ParseFromArray(buf.data(), buf.size());
 	if (!ok) {
 		NOTICE_LOG(COMMON, "ParseFromArray failed");
@@ -357,6 +397,10 @@ bool GdxsvBackendReplay::StartBuffer(const std::vector<u8> &buf, int pov) {
 void GdxsvBackendReplay::Stop() {
 	RestorePatch();
 	config::SkipFrame.reset();
+	ctrl_commands_.clear();
+	settings.gdxsv.skipRenderingHack = false;
+	settings.aica.muteAudio = false;
+	rend_enable_renderer(true);
 	gdxsv_save_state.EndUsing();
 	gdxsv.key_display_.enabled(false);
 	state_ = State::End;
@@ -371,7 +415,7 @@ void GdxsvBackendReplay::Stop() {
 		}
 
 		auto replay_file = replay_dir + "/" + log_file_.battle_code() + "_converted.pb";
-		FILE *f = nowide::fopen(replay_file.c_str(), "wb");
+		FILE* f = nowide::fopen(replay_file.c_str(), "wb");
 		if (f == nullptr) {
 			ERROR_LOG(COMMON, "SaveReplay: fopen failure");
 			return;
@@ -397,33 +441,33 @@ bool GdxsvBackendReplay::ChangeRoundAvailable() const {
 	return 0 < log_file_.start_msg_indexes_size() && log_file_.start_msg_indexes_size() == log_file_.start_msg_randoms_size();
 }
 
-void GdxsvBackendReplay::CtrlSpeedUp() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeSpeed, 1}); }
+void GdxsvBackendReplay::CtrlSpeedUp() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeSpeed, 1 }); }
 
-void GdxsvBackendReplay::CtrlSpeedDown() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeSpeed, -1}); }
+void GdxsvBackendReplay::CtrlSpeedDown() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeSpeed, -1 }); }
 
 void GdxsvBackendReplay::CtrlSetSpeed(int speed) {
-	ctrl_commands_.emplace_back(ReplayCtrlCommand{
+	ctrl_commands_.push_back(ReplayCtrlCommand{
 		ReplayCtrlCommand::SetSpeed,
 		speed,
-	});
+		});
 }
 
-void GdxsvBackendReplay::CtrlTogglePause() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::TogglePause}); }
+void GdxsvBackendReplay::CtrlTogglePause() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::TogglePause }); }
 
-void GdxsvBackendReplay::CtrlStepFrame() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::StepFrame}); }
+void GdxsvBackendReplay::CtrlStepFrame() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::StepFrame }); }
 
-void GdxsvBackendReplay::CtrlSomeFrameBackward() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameBackward}); }
+void GdxsvBackendReplay::CtrlSomeFrameBackward() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameBackward }); }
 
-void GdxsvBackendReplay::CtrlSomeFrameForward() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameForward}); }
+void GdxsvBackendReplay::CtrlSomeFrameForward() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameForward }); }
 
-void GdxsvBackendReplay::CtrlSetRound(int round) { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SetRound, round}); }
+void GdxsvBackendReplay::CtrlSetRound(int round) { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SetRound, round }); }
 
-void GdxsvBackendReplay::CtrlNextRound() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeRound, 1}); }
+void GdxsvBackendReplay::CtrlNextRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeRound, 1 }); }
 
-void GdxsvBackendReplay::CtrlPrevRound() { ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeRound, -1}); }
+void GdxsvBackendReplay::CtrlPrevRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeRound, -1 }); }
 
 void GdxsvBackendReplay::Open() {
-	recv_buf_.assign({0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd});
+	recv_buf_.assign({ 0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd });
 	state_ = State::McsSessionExchange;
 	ApplyPatch(true);
 }
@@ -437,11 +481,7 @@ void GdxsvBackendReplay::Close() {
 		PrintDisconnectionSummary();
 	}
 
-	RestorePatch();
-	config::SkipFrame.reset();
-	gdxsv_save_state.EndUsing();
-	gdxsv.key_display_.enabled(false);
-	state_ = State::End;
+	Stop();
 }
 
 u32 GdxsvBackendReplay::OnSockWrite(u32 addr, u32 size) {
@@ -451,7 +491,7 @@ u32 GdxsvBackendReplay::OnSockWrite(u32 addr, u32 size) {
 			buf[i] = gdxsv_ReadMem8(addr + i);
 		}
 
-		lbs_tx_reader_.Write((const char *)buf, size);
+		lbs_tx_reader_.Write((const char*)buf, size);
 		ProcessLbsMessage();
 	}
 
@@ -462,7 +502,8 @@ u32 GdxsvBackendReplay::OnSockWrite(u32 addr, u32 size) {
 u32 GdxsvBackendReplay::OnSockRead(u32 addr, u32 size) {
 	if (state_ <= State::LbsStartBattleFlow) {
 		ProcessLbsMessage();
-	} else {
+	}
+	else {
 		const int disk = gdxsv.Disk();
 		const int InetBuf = disk == 1 ? 0x0c310244 : 0x0c3ab984;
 		int msg_len = gdxsv_ReadMem8(InetBuf);
@@ -523,12 +564,12 @@ bool GdxsvBackendReplay::Start() {
 		// proto2 required fields was moved to UnknownFields
 		for (int i = 0; i < log_file_.battle_data_size(); ++i) {
 			auto data = log_file_.mutable_battle_data(i);
-			const auto &fields = proto::BattleLogFile::GetReflection()->GetUnknownFields(*data);
+			const auto& fields = proto::BattleLogFile::GetReflection()->GetUnknownFields(*data);
 			if (!fields.empty()) {
 				for (int j = 0; j < fields.field_count(); ++j) {
-					const auto &field = fields.field(j);
+					const auto& field = fields.field(j);
 					if (j == 0 && field.type() == google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
-						const auto &body = field.length_delimited();
+						const auto& body = field.length_delimited();
 						data->set_body(body.data(), body.size());
 					}
 					if (j == 1 && field.type() == google::protobuf::UnknownField::TYPE_VARINT) {
@@ -543,7 +584,7 @@ bool GdxsvBackendReplay::Start() {
 		McsMessageReader r;
 		McsMessage msg;
 		for (int i = 0; i < log_file_.battle_data_size(); ++i) {
-			const auto &data = log_file_.battle_data(i);
+			const auto& data = log_file_.battle_data(i);
 			if (player_position.find(data.user_id()) == player_position.end()) {
 				r.Write(data.body().data(), data.body().size());
 				while (r.Read(msg)) {
@@ -568,7 +609,7 @@ bool GdxsvBackendReplay::Start() {
 		}
 
 		std::sort(log_file_.mutable_users()->begin(), log_file_.mutable_users()->end(),
-				  [](const proto::BattleLogUser &a, const proto::BattleLogUser &b) { return a.pos() < b.pos(); });
+			[](const proto::BattleLogUser& a, const proto::BattleLogUser& b) { return a.pos() < b.pos(); });
 	}
 
 	if (log_file_.log_file_version() == 20230729) {
@@ -591,7 +632,7 @@ bool GdxsvBackendReplay::Start() {
 		McsMessage msg;
 		std::vector<std::vector<std::vector<u16>>> player_chunked_inputs(log_file_.users_size());
 
-		for (const auto &data : log_file_.battle_data()) {
+		for (const auto& data : log_file_.battle_data()) {
 			r.Write(data.body().data(), data.body().size());
 
 			while (r.Read(msg)) {
@@ -656,13 +697,14 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 	McsMessage msg;
 
 	for (int i = 0; i < log_file_.battle_data_size(); ++i) {
-		const auto &data = log_file_.battle_data(i);
+		const auto& data = log_file_.battle_data(i);
 		r.Write(data.body().data(), data.body().size());
 		while (r.Read(msg)) {
 			if (msg.Type() == McsMessage::KeyMsg2) {
 				msg_list.emplace_back(msg.FirstKeyMsg());
 				msg_list.emplace_back(msg.SecondKeyMsg());
-			} else {
+			}
+			else {
 				msg_list.emplace_back(msg);
 			}
 		}
@@ -671,7 +713,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 	std::vector<int> last_keymsg_seq(log_file_.users_size());
 	std::vector<int> last_force_msg_index(log_file_.users_size());
 	for (int i = 0; i < msg_list.size(); ++i) {
-		const auto &msg = msg_list[i];
+		const auto& msg = msg_list[i];
 		if (msg.Type() == McsMessage::KeyMsg1) {
 			last_keymsg_seq[msg.Sender()] = msg.FirstSeq();
 			last_force_msg_index[msg.Sender()] = 0;
@@ -689,7 +731,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 	NOTICE_LOG(COMMON, " KeyCount LastForceMsg UserID Name");
 	for (int i = 0; i < log_file_.users_size(); ++i) {
 		NOTICE_LOG(COMMON, "%9d %12d %6s %s", last_keymsg_seq[i], last_force_msg_index[i], log_file_.users(i).user_id().c_str(),
-				   log_file_.users(i).user_name().c_str());
+			log_file_.users(i).user_name().c_str());
 	}
 
 	const auto it_seq_min = std::min_element(begin(last_keymsg_seq), end(last_keymsg_seq));
@@ -702,7 +744,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 			NOTICE_LOG(COMMON, "!! Disconnected Player Detected !!");
 			NOTICE_LOG(COMMON, " KeyCount LastForceMsg UserID Name");
 			NOTICE_LOG(COMMON, "%9d %12d %6s %s", last_keymsg_seq[i], last_force_msg_index[i], log_file_.users(i).user_id().c_str(),
-					   log_file_.users(i).user_name().c_str());
+				log_file_.users(i).user_name().c_str());
 		}
 	}
 }
@@ -744,9 +786,9 @@ void GdxsvBackendReplay::ProcessLbsMessage() {
 				user.set_user_name_sjis("USER0" + std::to_string(pos));
 				auto game_param = user.game_param();
 				user.set_game_param(game_param.replace(16, 17,
-													   "\x82\x6F\x82\x68\x82\x6B\x82\x6E\x82\x73\x82\x4F\x82" +
-														   std::string(1, static_cast<char>(0x4F + pos)) +
-														   "\x01\x01\x07"));  // ＰＩＬＯＴ０１~０４
+					"\x82\x6F\x82\x68\x82\x6B\x82\x6E\x82\x73\x82\x4F\x82" +
+					std::string(1, static_cast<char>(0x4F + pos)) +
+					"\x01\x01\x07"));  // ＰＩＬＯＴ０１~０４
 				user.set_battle_count(0);
 				user.set_win_count(0);
 				user.set_lose_count(0);
@@ -793,26 +835,29 @@ void GdxsvBackendReplay::ProcessLbsMessage() {
 	}
 }
 
-void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
+void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 	const auto msg_type = msg.Type();
 
 	if (msg_type == McsMessage::MsgType::ConnectionIdMsg) {
 		state_ = State::McsInBattle;
-	} else if (msg_type == McsMessage::MsgType::IntroMsg) {
+	}
+	else if (msg_type == McsMessage::MsgType::IntroMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto intro_msg = McsMessage::Create(McsMessage::MsgType::IntroMsg, i);
 				std::copy(intro_msg.body.begin(), intro_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	} else if (msg_type == McsMessage::MsgType::IntroMsgReturn) {
+	}
+	else if (msg_type == McsMessage::MsgType::IntroMsgReturn) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto intro_msg = McsMessage::Create(McsMessage::MsgType::IntroMsgReturn, i);
 				std::copy(intro_msg.body.begin(), intro_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	} else if (msg_type == McsMessage::MsgType::PingMsg) {
+	}
+	else if (msg_type == McsMessage::MsgType::PingMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto pong_msg = McsMessage::Create(McsMessage::MsgType::PongMsg, i);
@@ -821,10 +866,13 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
 				std::copy(pong_msg.body.begin(), pong_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	} else if (msg_type == McsMessage::MsgType::PongMsg) {
+	}
+	else if (msg_type == McsMessage::MsgType::PongMsg) {
 		// do nothing
-	} else if (msg_type == McsMessage::MsgType::StartMsg) {
+	}
+	else if (msg_type == McsMessage::MsgType::StartMsg) {
 		start_msg_count_++;
+		NOTICE_LOG(COMMON, "StartMsg key_msg_count %d", key_msg_count_);
 
 		if (start_msg_count_ - 1 < log_file_.start_msg_indexes_size()) {
 			const auto it = std::lower_bound(log_file_.start_msg_indexes().begin(), log_file_.start_msg_indexes().end(), key_msg_count_);
@@ -832,7 +880,8 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
 				NOTICE_LOG(COMMON, "key_msg_count updates %d -> %d", key_msg_count_, *it);
 				key_msg_count_ = *it;
 			}
-		} else {
+		}
+		else {
 			log_file_.add_start_msg_indexes(key_msg_count_);
 		}
 
@@ -840,22 +889,26 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
 		const auto random_data = gdxsv_ReadMem16(k_rnd0);
 		if (start_msg_count_ - 1 < log_file_.start_msg_randoms_size()) {
 			verify(random_data == (log_file_.start_msg_randoms(start_msg_count_ - 1) & 0xffffu));
-		} else {
+		}
+		else {
 			log_file_.add_start_msg_randoms(random_data);
 		}
 
-		ctrl_commands_.emplace_front(ReplayCtrlCommand{ReplayCtrlCommand::SetMaxLag, 1});
-		ctrl_commands_.emplace_front(ReplayCtrlCommand{ReplayCtrlCommand::SaveFirstFrame});
-		ctrl_commands_.emplace_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing});
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto start_msg = McsMessage::Create(McsMessage::MsgType::StartMsg, i);
 				std::copy(start_msg.body.begin(), start_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	} else if (msg_type == McsMessage::MsgType::ForceMsg) {
+
+		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SaveFirstFrame });
+		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SetMaxLag, 1 });
+		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
+	}
+	else if (msg_type == McsMessage::MsgType::ForceMsg) {
 		// do nothing
-	} else if (msg_type == McsMessage::MsgType::KeyMsg1) {
+	}
+	else if (msg_type == McsMessage::MsgType::KeyMsg1) {
 		gdxsv.maxlag_ = 0;
 
 		if (ctrl_play_speed_ < 0) {
@@ -881,9 +934,11 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
 				}
 			}
 		}
-	} else if (msg_type == McsMessage::MsgType::KeyMsg2) {
+	}
+	else if (msg_type == McsMessage::MsgType::KeyMsg2) {
 		verify(false);
-	} else if (msg_type == McsMessage::MsgType::LoadEndMsg) {
+	}
+	else if (msg_type == McsMessage::MsgType::LoadEndMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto load_start_msg = McsMessage::Create(McsMessage::MsgType::LoadStartMsg, i);
@@ -896,7 +951,8 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage &msg) {
 				std::copy(load_end_msg.body.begin(), load_end_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	} else {
+	}
+	else {
 		WARN_LOG(COMMON, "unhandled mcs msg: %s", McsMessage::MsgTypeName(msg_type));
 		WARN_LOG(COMMON, "%s", msg.ToHex().c_str());
 	}
@@ -925,8 +981,8 @@ void GdxsvBackendReplay::ApplyPatch(bool first_time) {
 	}
 
 	// Online Patch
-	for (const auto &patch : log_file_.patches()) {
-		for (const auto &code : patch.codes()) {
+	for (const auto& patch : log_file_.patches()) {
+		for (const auto& code : patch.codes()) {
 			gdxsv_WriteMem(code.size(), code.address(), code.changed());
 		}
 	}
@@ -943,8 +999,8 @@ void GdxsvBackendReplay::RestorePatch() {
 	}
 
 	// Online Patch
-	for (const auto &patch : log_file_.patches()) {
-		for (const auto &code : patch.codes()) {
+	for (const auto& patch : log_file_.patches()) {
+		for (const auto& code : patch.codes()) {
 			gdxsv_WriteMem(code.size(), code.address(), code.original());
 		}
 	}
@@ -955,7 +1011,7 @@ void GdxsvBackendReplay::RenderPauseMenu() {
 	ImGui::SetNextWindowSize(ScaledVec2(330, 0));
 
 	ImGui::Begin("##gdxsv-replay-pause", NULL,
-				 ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize);
+		ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize);
 
 	ImGui::Columns(2, "buttons", false);
 	if (ImGui::Button("Stop Replay", ScaledVec2(150, 50))) {

--- a/core/gdxsv/gdxsv_backend_replay.cpp
+++ b/core/gdxsv/gdxsv_backend_replay.cpp
@@ -56,7 +56,7 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 
 	if (state_ == State::Start) {
 		kcode[0] = ~0x0004u;
-		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameForward, 60 });
+		ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameForward, 60});
 	}
 
 	if (state_ == State::McsInBattle) {
@@ -65,11 +65,10 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 		if (gdxsv_ReadMem8(COM_R_No0) == 4 && (gdxsv_ReadMem8(COM_R_No0 + 5) == 3 || gdxsv_ReadMem8(COM_R_No0 + 5) == 4)) {
 			// re-battle end
 			Stop();
-		}
-		else if (gdxsv_ReadMem8(COM_R_No0) == 4 && gdxsv_ReadMem8(COM_R_No0 + 5) != 0) {
+		} else if (gdxsv_ReadMem8(COM_R_No0) == 4 && gdxsv_ReadMem8(COM_R_No0 + 5) != 0) {
 			// not game scene
 			if (ctrl_commands_.empty()) {
-				ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
+				ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing});
 			}
 		}
 	}
@@ -100,8 +99,7 @@ void GdxsvBackendReplay::OnMainUiLoop() {
 			if (~input.kcode & DC_BTN_X) {
 				if (~pressed_kcode & (BTN_TRIGGER_RIGHT | DC_BTN_Z)) CtrlSomeFrameForward();
 				if (~pressed_kcode & (BTN_TRIGGER_LEFT | DC_BTN_C)) CtrlSomeFrameBackward();
-			}
-			else {
+			} else {
 				if (~pressed_kcode & DC_BTN_B) CtrlSetSpeed(0), CtrlTogglePause();
 				if (~pressed_kcode & DC_BTN_A) CtrlSetSpeed(0), CtrlStepFrame();
 				if (~pressed_kcode & (BTN_TRIGGER_RIGHT | DC_BTN_Z)) CtrlSetSpeed(0), CtrlNextRound();
@@ -129,16 +127,14 @@ void GdxsvBackendReplay::OnNextFrame() {
 	constexpr int save_interval = 180;
 	auto in_briefing = [disk = gdxsv.Disk()]() -> bool {
 		return disk == 1 ? gdxsv_ReadMem8(0x0c336254) == 2 && gdxsv_ReadMem8(0x0c336255) == 5
-			: gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 5;
+						 : gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 5;
 	};
 	auto in_game = [disk = gdxsv.Disk()]() -> bool {
 		return disk == 1 ? gdxsv_ReadMem8(0x0c336254) == 2 && gdxsv_ReadMem8(0x0c336255) == 7
-			: gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 7;
+						 : gdxsv_ReadMem8(0x0c3d16d4) == 2 && gdxsv_ReadMem8(0x0c3d16d5) == 7;
 	};
 
-	auto need_cancel = [&]() -> bool {
-		return ctrl_commands_.contains(ReplayCtrlCommand::SaveFirstFrame) || state_ == State::End;
-	};
+	auto need_cancel = [&]() -> bool { return ctrl_commands_.contains(ReplayCtrlCommand::SaveFirstFrame) || state_ == State::End; };
 
 	gdxsv.key_display_.enabled(config::GdxReplayKeyDisplay && in_game());
 
@@ -214,7 +210,8 @@ void GdxsvBackendReplay::OnNextFrame() {
 				seeking_ = true;
 				emu.run();
 				// Regular save state
-				if ((in_briefing() || in_game()) && gdxsv_save_state.LastSavedFrame() + save_interval <= key_msg_count_ && recv_buf_.empty()) {
+				if ((in_briefing() || in_game()) && gdxsv_save_state.LastSavedFrame() + save_interval <= key_msg_count_ &&
+					recv_buf_.empty()) {
 					gdxsv_save_state.SaveState(key_msg_count_);
 				}
 				settings.aica.muteAudio = false;
@@ -227,7 +224,8 @@ void GdxsvBackendReplay::OnNextFrame() {
 
 			if (0 < skipped_frame) {
 				const auto ms = duration_cast<milliseconds>(high_resolution_clock::now() - t0).count();
-				NOTICE_LOG(COMMON, "SomeFrameForward skipped %d[fr] in %ld[ms] (%.2f[ms/fr]) %d->%d(%d keys)", skipped_frame, ms, (float)ms / skipped_frame, prev_key_msg_count, key_msg_count_, key_msg_count_ - prev_key_msg_count);
+				NOTICE_LOG(COMMON, "SomeFrameForward skipped %d[fr] in %ld[ms] (%.2f[ms/fr]) %d->%d(%d keys)", skipped_frame, ms,
+						   (float)ms / skipped_frame, prev_key_msg_count, key_msg_count_, key_msg_count_ - prev_key_msg_count);
 				char buf[256];
 				sprintf_s(buf, "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
 				gui_display_notification(buf, duration);
@@ -327,7 +325,7 @@ void GdxsvBackendReplay::OnNextFrame() {
 				gdxsv.maxlag_ = 1;	// for StartMsg
 				NOTICE_LOG(COMMON, "ctrl_change_round_:%d key_msg_count_:%d", round, key_msg_count_);
 				NOTICE_LOG(COMMON, "start_msg_randoms_size:%d", log_file_.start_msg_randoms_size());
-				ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
+				ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing});
 			}
 
 			ctrl_commands_.pop_front();
@@ -340,7 +338,7 @@ bool GdxsvBackendReplay::OnOpenMenu() {
 		return false;
 	}
 
-	ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::TogglePauseMenu });
+	ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::TogglePauseMenu});
 
 	return false;
 }
@@ -441,33 +439,33 @@ bool GdxsvBackendReplay::ChangeRoundAvailable() const {
 	return 0 < log_file_.start_msg_indexes_size() && log_file_.start_msg_indexes_size() == log_file_.start_msg_randoms_size();
 }
 
-void GdxsvBackendReplay::CtrlSpeedUp() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeSpeed, 1 }); }
+void GdxsvBackendReplay::CtrlSpeedUp() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeSpeed, 1}); }
 
-void GdxsvBackendReplay::CtrlSpeedDown() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeSpeed, -1 }); }
+void GdxsvBackendReplay::CtrlSpeedDown() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeSpeed, -1}); }
 
 void GdxsvBackendReplay::CtrlSetSpeed(int speed) {
 	ctrl_commands_.push_back(ReplayCtrlCommand{
 		ReplayCtrlCommand::SetSpeed,
 		speed,
-		});
+	});
 }
 
-void GdxsvBackendReplay::CtrlTogglePause() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::TogglePause }); }
+void GdxsvBackendReplay::CtrlTogglePause() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::TogglePause}); }
 
-void GdxsvBackendReplay::CtrlStepFrame() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::StepFrame }); }
+void GdxsvBackendReplay::CtrlStepFrame() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::StepFrame}); }
 
-void GdxsvBackendReplay::CtrlSomeFrameBackward() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameBackward }); }
+void GdxsvBackendReplay::CtrlSomeFrameBackward() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameBackward}); }
 
-void GdxsvBackendReplay::CtrlSomeFrameForward() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SomeFrameForward }); }
+void GdxsvBackendReplay::CtrlSomeFrameForward() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SomeFrameForward}); }
 
-void GdxsvBackendReplay::CtrlSetRound(int round) { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SetRound, round }); }
+void GdxsvBackendReplay::CtrlSetRound(int round) { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SetRound, round}); }
 
-void GdxsvBackendReplay::CtrlNextRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeRound, 1 }); }
+void GdxsvBackendReplay::CtrlNextRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeRound, 1}); }
 
-void GdxsvBackendReplay::CtrlPrevRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::ChangeRound, -1 }); }
+void GdxsvBackendReplay::CtrlPrevRound() { ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::ChangeRound, -1}); }
 
 void GdxsvBackendReplay::Open() {
-	recv_buf_.assign({ 0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd });
+	recv_buf_.assign({0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd});
 	state_ = State::McsSessionExchange;
 	ApplyPatch(true);
 }
@@ -502,8 +500,7 @@ u32 GdxsvBackendReplay::OnSockWrite(u32 addr, u32 size) {
 u32 GdxsvBackendReplay::OnSockRead(u32 addr, u32 size) {
 	if (state_ <= State::LbsStartBattleFlow) {
 		ProcessLbsMessage();
-	}
-	else {
+	} else {
 		const int disk = gdxsv.Disk();
 		const int InetBuf = disk == 1 ? 0x0c310244 : 0x0c3ab984;
 		int msg_len = gdxsv_ReadMem8(InetBuf);
@@ -609,7 +606,7 @@ bool GdxsvBackendReplay::Start() {
 		}
 
 		std::sort(log_file_.mutable_users()->begin(), log_file_.mutable_users()->end(),
-			[](const proto::BattleLogUser& a, const proto::BattleLogUser& b) { return a.pos() < b.pos(); });
+				  [](const proto::BattleLogUser& a, const proto::BattleLogUser& b) { return a.pos() < b.pos(); });
 	}
 
 	if (log_file_.log_file_version() == 20230729) {
@@ -703,8 +700,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 			if (msg.Type() == McsMessage::KeyMsg2) {
 				msg_list.emplace_back(msg.FirstKeyMsg());
 				msg_list.emplace_back(msg.SecondKeyMsg());
-			}
-			else {
+			} else {
 				msg_list.emplace_back(msg);
 			}
 		}
@@ -731,7 +727,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 	NOTICE_LOG(COMMON, " KeyCount LastForceMsg UserID Name");
 	for (int i = 0; i < log_file_.users_size(); ++i) {
 		NOTICE_LOG(COMMON, "%9d %12d %6s %s", last_keymsg_seq[i], last_force_msg_index[i], log_file_.users(i).user_id().c_str(),
-			log_file_.users(i).user_name().c_str());
+				   log_file_.users(i).user_name().c_str());
 	}
 
 	const auto it_seq_min = std::min_element(begin(last_keymsg_seq), end(last_keymsg_seq));
@@ -744,7 +740,7 @@ void GdxsvBackendReplay::PrintDisconnectionSummary() {
 			NOTICE_LOG(COMMON, "!! Disconnected Player Detected !!");
 			NOTICE_LOG(COMMON, " KeyCount LastForceMsg UserID Name");
 			NOTICE_LOG(COMMON, "%9d %12d %6s %s", last_keymsg_seq[i], last_force_msg_index[i], log_file_.users(i).user_id().c_str(),
-				log_file_.users(i).user_name().c_str());
+					   log_file_.users(i).user_name().c_str());
 		}
 	}
 }
@@ -786,9 +782,9 @@ void GdxsvBackendReplay::ProcessLbsMessage() {
 				user.set_user_name_sjis("USER0" + std::to_string(pos));
 				auto game_param = user.game_param();
 				user.set_game_param(game_param.replace(16, 17,
-					"\x82\x6F\x82\x68\x82\x6B\x82\x6E\x82\x73\x82\x4F\x82" +
-					std::string(1, static_cast<char>(0x4F + pos)) +
-					"\x01\x01\x07"));  // ＰＩＬＯＴ０１~０４
+													   "\x82\x6F\x82\x68\x82\x6B\x82\x6E\x82\x73\x82\x4F\x82" +
+														   std::string(1, static_cast<char>(0x4F + pos)) +
+														   "\x01\x01\x07"));  // ＰＩＬＯＴ０１~０４
 				user.set_battle_count(0);
 				user.set_win_count(0);
 				user.set_lose_count(0);
@@ -840,24 +836,21 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 
 	if (msg_type == McsMessage::MsgType::ConnectionIdMsg) {
 		state_ = State::McsInBattle;
-	}
-	else if (msg_type == McsMessage::MsgType::IntroMsg) {
+	} else if (msg_type == McsMessage::MsgType::IntroMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto intro_msg = McsMessage::Create(McsMessage::MsgType::IntroMsg, i);
 				std::copy(intro_msg.body.begin(), intro_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	}
-	else if (msg_type == McsMessage::MsgType::IntroMsgReturn) {
+	} else if (msg_type == McsMessage::MsgType::IntroMsgReturn) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto intro_msg = McsMessage::Create(McsMessage::MsgType::IntroMsgReturn, i);
 				std::copy(intro_msg.body.begin(), intro_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	}
-	else if (msg_type == McsMessage::MsgType::PingMsg) {
+	} else if (msg_type == McsMessage::MsgType::PingMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto pong_msg = McsMessage::Create(McsMessage::MsgType::PongMsg, i);
@@ -866,11 +859,9 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 				std::copy(pong_msg.body.begin(), pong_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	}
-	else if (msg_type == McsMessage::MsgType::PongMsg) {
+	} else if (msg_type == McsMessage::MsgType::PongMsg) {
 		// do nothing
-	}
-	else if (msg_type == McsMessage::MsgType::StartMsg) {
+	} else if (msg_type == McsMessage::MsgType::StartMsg) {
 		start_msg_count_++;
 		NOTICE_LOG(COMMON, "StartMsg key_msg_count %d", key_msg_count_);
 
@@ -880,8 +871,7 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 				NOTICE_LOG(COMMON, "key_msg_count updates %d -> %d", key_msg_count_, *it);
 				key_msg_count_ = *it;
 			}
-		}
-		else {
+		} else {
 			log_file_.add_start_msg_indexes(key_msg_count_);
 		}
 
@@ -889,8 +879,7 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 		const auto random_data = gdxsv_ReadMem16(k_rnd0);
 		if (start_msg_count_ - 1 < log_file_.start_msg_randoms_size()) {
 			verify(random_data == (log_file_.start_msg_randoms(start_msg_count_ - 1) & 0xffffu));
-		}
-		else {
+		} else {
 			log_file_.add_start_msg_randoms(random_data);
 		}
 
@@ -901,14 +890,12 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 			}
 		}
 
-		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SaveFirstFrame });
-		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SetMaxLag, 1 });
-		ctrl_commands_.push_back(ReplayCtrlCommand{ ReplayCtrlCommand::SeekToBriefing });
-	}
-	else if (msg_type == McsMessage::MsgType::ForceMsg) {
+		ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SaveFirstFrame});
+		ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SetMaxLag, 1});
+		ctrl_commands_.push_back(ReplayCtrlCommand{ReplayCtrlCommand::SeekToBriefing});
+	} else if (msg_type == McsMessage::MsgType::ForceMsg) {
 		// do nothing
-	}
-	else if (msg_type == McsMessage::MsgType::KeyMsg1) {
+	} else if (msg_type == McsMessage::MsgType::KeyMsg1) {
 		gdxsv.maxlag_ = 0;
 
 		if (ctrl_play_speed_ < 0) {
@@ -934,11 +921,9 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 				}
 			}
 		}
-	}
-	else if (msg_type == McsMessage::MsgType::KeyMsg2) {
+	} else if (msg_type == McsMessage::MsgType::KeyMsg2) {
 		verify(false);
-	}
-	else if (msg_type == McsMessage::MsgType::LoadEndMsg) {
+	} else if (msg_type == McsMessage::MsgType::LoadEndMsg) {
 		for (int i = 0; i < log_file_.users_size(); ++i) {
 			if (i != pov_) {
 				auto load_start_msg = McsMessage::Create(McsMessage::MsgType::LoadStartMsg, i);
@@ -951,8 +936,7 @@ void GdxsvBackendReplay::ProcessMcsMessage(const McsMessage& msg) {
 				std::copy(load_end_msg.body.begin(), load_end_msg.body.end(), std::back_inserter(recv_buf_));
 			}
 		}
-	}
-	else {
+	} else {
 		WARN_LOG(COMMON, "unhandled mcs msg: %s", McsMessage::MsgTypeName(msg_type));
 		WARN_LOG(COMMON, "%s", msg.ToHex().c_str());
 	}
@@ -1011,7 +995,7 @@ void GdxsvBackendReplay::RenderPauseMenu() {
 	ImGui::SetNextWindowSize(ScaledVec2(330, 0));
 
 	ImGui::Begin("##gdxsv-replay-pause", NULL,
-		ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize);
+				 ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize);
 
 	ImGui::Columns(2, "buttons", false);
 	if (ImGui::Button("Stop Replay", ScaledVec2(150, 50))) {

--- a/core/gdxsv/gdxsv_backend_replay.cpp
+++ b/core/gdxsv/gdxsv_backend_replay.cpp
@@ -227,7 +227,7 @@ void GdxsvBackendReplay::OnNextFrame() {
 				NOTICE_LOG(COMMON, "SomeFrameForward skipped %d[fr] in %ld[ms] (%.2f[ms/fr]) %d->%d(%d keys)", skipped_frame, ms,
 						   (float)ms / skipped_frame, prev_key_msg_count, key_msg_count_, key_msg_count_ - prev_key_msg_count);
 				char buf[256];
-				sprintf_s(buf, "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
+				snprintf(buf, sizeof(buf), "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
 				gui_display_notification(buf, duration);
 			}
 			ctrl_commands_.pop_front();
@@ -256,7 +256,7 @@ void GdxsvBackendReplay::OnNextFrame() {
 				const auto ms = duration_cast<milliseconds>(high_resolution_clock::now() - t0).count();
 				NOTICE_LOG(COMMON, "SeekToBriefing skipped %d[fr] in %ld[ms] (%.2f[ms/fr])", skipped_frame, ms, (float)ms / skipped_frame);
 				char buf[256];
-				sprintf_s(buf, "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
+				snprintf(buf, sizeof(buf), "Skipped %d frames %.2f[ms/fr]", skipped_frame, (float)ms / skipped_frame);
 				gui_display_notification(buf, duration);
 			}
 

--- a/core/gdxsv/gdxsv_backend_replay.h
+++ b/core/gdxsv/gdxsv_backend_replay.h
@@ -54,8 +54,8 @@ class GdxsvBackendReplay {
 	bool OnOpenMenu();
 	void DisplayOSD();
 
-	bool StartFile(const char *path, int pov);
-	bool StartBuffer(const std::vector<u8> &buf, int pov);
+	bool StartFile(const char* path, int pov);
+	bool StartBuffer(const std::vector<u8>& buf, int pov);
 	void Stop();
 	bool ChangeRoundAvailable() const;
 
@@ -66,11 +66,11 @@ class GdxsvBackendReplay {
 	u32 OnSockRead(u32 addr, u32 size);
 	u32 OnSockPoll();
 
-private:
+   private:
 	bool Start();
 	void PrintDisconnectionSummary();
 	void ProcessLbsMessage();
-	void ProcessMcsMessage(const McsMessage &msg);
+	void ProcessMcsMessage(const McsMessage& msg);
 	void ApplyPatch(bool first_time);
 	void RestorePatch();
 	void RenderPauseMenu();
@@ -89,7 +89,7 @@ private:
 
 	State state_;
 	class {
-	public:
+	   public:
 		void push_back(const ReplayCtrlCommand& cmd) {
 			std::lock_guard lock(mtx_);
 			cmds_.push_back(cmd);
@@ -127,7 +127,8 @@ private:
 			std::lock_guard lock(mtx_);
 			cmds_.clear();
 		}
-	private:
+
+	   private:
 		std::recursive_mutex mtx_;
 		std::deque<ReplayCtrlCommand> cmds_;
 	} ctrl_commands_;

--- a/core/gdxsv/gdxsv_backend_replay.h
+++ b/core/gdxsv/gdxsv_backend_replay.h
@@ -45,13 +45,12 @@ class GdxsvBackendReplay {
 		Command cmd;
 		int arg1;
 		int arg2;
-		int var1;
-		int var2;
 	};
 
 	void Reset();
 	void OnMainUiLoop();
-	void OnVBlank();
+	void OnEndOfFrame();
+	void OnNextFrame();
 	bool OnOpenMenu();
 	void DisplayOSD();
 
@@ -60,7 +59,23 @@ class GdxsvBackendReplay {
 	void Stop();
 	bool ChangeRoundAvailable() const;
 
-	// Replay control
+	// Network Backend Interface
+	void Open();
+	void Close();
+	u32 OnSockWrite(u32 addr, u32 size);
+	u32 OnSockRead(u32 addr, u32 size);
+	u32 OnSockPoll();
+
+private:
+	bool Start();
+	void PrintDisconnectionSummary();
+	void ProcessLbsMessage();
+	void ProcessMcsMessage(const McsMessage &msg);
+	void ApplyPatch(bool first_time);
+	void RestorePatch();
+	void RenderPauseMenu();
+
+	// Replay control (need mutex lock)
 	void CtrlSpeedUp();
 	void CtrlSpeedDown();
 	void CtrlSetSpeed(int speed);
@@ -72,23 +87,52 @@ class GdxsvBackendReplay {
 	void CtrlNextRound();
 	void CtrlPrevRound();
 
-	// Network Backend Interface
-	void Open();
-	void Close();
-	u32 OnSockWrite(u32 addr, u32 size);
-	u32 OnSockRead(u32 addr, u32 size);
-	u32 OnSockPoll();
-
-   private:
-	bool Start();
-	void PrintDisconnectionSummary();
-	void ProcessLbsMessage();
-	void ProcessMcsMessage(const McsMessage &msg);
-	void ApplyPatch(bool first_time);
-	void RestorePatch();
-	void RenderPauseMenu();
-
 	State state_;
+	class {
+	public:
+		void push_back(const ReplayCtrlCommand& cmd) {
+			std::lock_guard lock(mtx_);
+			cmds_.push_back(cmd);
+		}
+		void pop_front() {
+			std::lock_guard lock(mtx_);
+			if (!cmds_.empty()) cmds_.pop_front();
+		}
+		bool try_get_front(ReplayCtrlCommand& cmd) {
+			std::lock_guard lock(mtx_);
+			if (!cmds_.empty()) {
+				cmd = cmds_.front();
+				return true;
+			}
+			return false;
+		}
+		size_t size() {
+			std::lock_guard lock(mtx_);
+			return cmds_.size();
+		}
+		bool empty() {
+			std::lock_guard lock(mtx_);
+			return cmds_.empty();
+		}
+		bool contains(ReplayCtrlCommand::Command c) {
+			std::lock_guard lock(mtx_);
+			for (const auto& cmd : cmds_) {
+				if (cmd.cmd == c) {
+					return true;
+				}
+			}
+			return false;
+		}
+		void clear() {
+			std::lock_guard lock(mtx_);
+			cmds_.clear();
+		}
+	private:
+		std::recursive_mutex mtx_;
+		std::deque<ReplayCtrlCommand> cmds_;
+	} ctrl_commands_;
+	bool end_of_frame_;
+	bool seeking_;
 	bool pause_menu_opend_;
 	LbsMessageReader lbs_tx_reader_;
 	proto::BattleLogFile log_file_;
@@ -97,7 +141,6 @@ class GdxsvBackendReplay {
 	int recv_delay_;
 	int start_msg_count_;
 	int key_msg_count_;
-	std::deque<ReplayCtrlCommand> ctrl_commands_;
 	bool ctrl_pause_;
 	int ctrl_play_speed_;
 	int ctrl_step_frame_;

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -358,11 +358,9 @@ void gdxsv_emu_gui_settings() {
 	OptionCheckbox("Display Network Statistics", config::NetworkStats,
 				   "Display network statistics on screen by default.\nUse Flycast Menu button to show/hide.");
 
-	OptionCheckbox("SkipRenderingHack", config::GdxSkipRenderingHack,
-				   "Skip graphic updates when rolling back.");
+	OptionCheckbox("SkipRenderingHack", config::GdxSkipRenderingHack, "Skip graphic updates when rolling back.");
 
-	OptionCheckbox("SlowIdleLoopHack", config::GdxSlowIdleLoopHack,
-				   "Reduce idle loop when rendering.");
+	OptionCheckbox("SlowIdleLoopHack", config::GdxSlowIdleLoopHack, "Reduce idle loop when rendering.");
 }
 
 void gdxsv_gui_display_osd() { gdxsv.DisplayOSD(); }

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -33,10 +33,6 @@ bool gdxsv_is_online() { return gdxsv.IsOnline(); }
 
 bool gdxsv_is_savestate_allowed() { return gdxsv.IsSaveStateAllowed(); }
 
-bool gdxsv_is_replaying() { return gdxsv.IsReplaying(); }
-
-void gdxsv_stop_replay() { gdxsv.StopReplay(); }
-
 void gdxsv_emu_flycast_init() { config::GGPOEnable = false; }
 
 void gdxsv_emu_start() {
@@ -61,6 +57,18 @@ void gdxsv_emu_reset() { gdxsv.Reset(); }
 void gdxsv_emu_vblank() {
 	if (gdxsv.Enabled()) {
 		gdxsv.HookVBlank();
+	}
+}
+
+void gdxsv_emu_end_frame() {
+	if (gdxsv.Enabled()) {
+		gdxsv.HookEndOfFrame();
+	}
+}
+
+void gdxsv_emu_next_frame() {
+	if (gdxsv.Enabled()) {
+		gdxsv.HookNextFrame();
 	}
 }
 
@@ -349,6 +357,12 @@ void gdxsv_emu_gui_settings() {
 
 	OptionCheckbox("Display Network Statistics", config::NetworkStats,
 				   "Display network statistics on screen by default.\nUse Flycast Menu button to show/hide.");
+
+	OptionCheckbox("SkipRenderingHack", config::GdxSkipRenderingHack,
+				   "Skip graphic updates when rolling back.");
+
+	OptionCheckbox("SlowIdleLoopHack", config::GdxSlowIdleLoopHack,
+				   "Reduce idle loop when rendering.");
 }
 
 void gdxsv_gui_display_osd() { gdxsv.DisplayOSD(); }

--- a/core/gdxsv/gdxsv_emu_hooks.h
+++ b/core/gdxsv/gdxsv_emu_hooks.h
@@ -16,10 +16,6 @@ bool gdxsv_is_online();
 
 bool gdxsv_is_savestate_allowed();
 
-bool gdxsv_is_replaying();
-
-void gdxsv_stop_replay();
-
 void gdxsv_emu_flycast_init();
 
 void gdxsv_emu_start();
@@ -27,6 +23,10 @@ void gdxsv_emu_start();
 void gdxsv_emu_reset();
 
 void gdxsv_emu_vblank();
+
+void gdxsv_emu_end_frame();
+
+void gdxsv_emu_next_frame();
 
 void gdxsv_emu_mainui_loop();
 

--- a/core/gdxsv/gdxsv_prof.cpp
+++ b/core/gdxsv/gdxsv_prof.cpp
@@ -1,0 +1,10 @@
+#include "gdxsv_prof.h"
+#include "log/LogManager.h"
+
+void GdxsvProf::Print() {
+	for (auto& p : duration_) {
+		NOTICE_LOG(COMMON, "%s\t%ld[ms]", p.first.c_str(), std::chrono::duration_cast<std::chrono::milliseconds>(p.second).count());
+	}
+}
+
+GdxsvProf gdxsv_prof;

--- a/core/gdxsv/gdxsv_prof.cpp
+++ b/core/gdxsv/gdxsv_prof.cpp
@@ -1,4 +1,5 @@
 #include "gdxsv_prof.h"
+
 #include "log/LogManager.h"
 
 void GdxsvProf::Print() {

--- a/core/gdxsv/gdxsv_prof.h
+++ b/core/gdxsv/gdxsv_prof.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <chrono>
+#include <map>
+#include <string>
+
+class GdxsvProf
+{
+public:
+	void Start(const char* name) {
+		if (t0_.find(name) != t0_.end()) return;
+		t0_[name] = std::chrono::high_resolution_clock::now();
+	}
+
+	void Stop(const char* name) {
+		if (t0_.find(name) == t0_.end()) return;
+		duration_[name] += std::chrono::high_resolution_clock::now() - t0_[name];
+		t0_.erase(name);
+	}
+
+	void Print();
+
+	void Reset() {
+		t0_.clear();
+		duration_.clear();
+	}
+
+private:
+	std::map<std::string, std::chrono::high_resolution_clock::time_point> t0_;
+	std::map<std::string, std::chrono::high_resolution_clock::duration> duration_;
+};
+
+extern GdxsvProf gdxsv_prof;

--- a/core/gdxsv/gdxsv_prof.h
+++ b/core/gdxsv/gdxsv_prof.h
@@ -3,9 +3,8 @@
 #include <map>
 #include <string>
 
-class GdxsvProf
-{
-public:
+class GdxsvProf {
+   public:
 	void Start(const char* name) {
 		if (t0_.find(name) != t0_.end()) return;
 		t0_[name] = std::chrono::high_resolution_clock::now();
@@ -24,7 +23,7 @@ public:
 		duration_.clear();
 	}
 
-private:
+   private:
 	std::map<std::string, std::chrono::high_resolution_clock::time_point> t0_;
 	std::map<std::string, std::chrono::high_resolution_clock::duration> duration_;
 };

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -395,8 +395,10 @@ void rend_start_render()
 	ctx->rend.fog_clamp_min = FOG_CLAMP_MIN;
 	ctx->rend.fog_clamp_max = FOG_CLAMP_MAX;
 
-	if (!ctx->rend.isRTT)
+	if (!ctx->rend.isRTT) {
+		gdxsv_emu_end_frame();
 		ggpo::endOfFrame();
+	}
 
 	if (QueueRender(ctx))
 	{

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -55,6 +55,14 @@ static DynarecCodeEntryPtr DYNACALL bm_GetCode(u32 addr)
 // This returns an executable address
 DynarecCodeEntryPtr DYNACALL bm_GetCodeByVAddr(u32 addr)
 {
+	if (settings.gdxsv.disk == 2) {
+		// Hack: skip something of game rendering function
+		if (addr == 0x0c0520e2 && settings.gdxsv.skipRenderingHack) {
+			next_pc += 4;
+			addr = next_pc;
+		}
+	}
+
 	if (!mmu_enabled())
 		return bm_GetCode(addr);
 

--- a/core/hw/sh4/dyna/decoder.cpp
+++ b/core/hw/sh4/dyna/decoder.cpp
@@ -1059,6 +1059,13 @@ _end:
 	
 	blk->guest_cycles = std::round(blk->guest_cycles * 200.f / std::max(1.f, (float)config::Sh4Clock));
 
+	// Hack: slow idle loop
+	if (config::GdxSlowIdleLoopHack) {
+		if (settings.gdxsv.disk == 2 && blk->addr == 0x0c2ccdba) {
+			blk->guest_cycles = SH4_TIMESLICE;
+		}
+	}
+
 	//make sure we don't use wayy-too-few cycles
 	blk->guest_cycles = std::max(1U, blk->guest_cycles);
 	blk = nullptr;

--- a/core/network/ggpo.cpp
+++ b/core/network/ggpo.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 
 #include "gdxsv/gdxsv_emu_hooks.h"
+#include "gdxsv/gdxsv_prof.h"
 
 void UpdateInputState();
 
@@ -165,6 +166,7 @@ struct MemPages
 };
 static std::unordered_map<int, MemPages> deltaStates;
 static int lastSavedFrame = -1;
+static int seekToFrame = -1;
 static int totalRollbackFrames;
 static int totalTimeSync;
 static int timesyncOccurred;
@@ -289,7 +291,11 @@ static bool on_event(GGPOEvent *info)
 static bool advance_frame(int)
 {
 	INFO_LOG(NETWORK, "advance_frame");
+	int frame;
+	getCurrentFrame(&frame);
+
 	settings.aica.muteAudio = true;
+	settings.gdxsv.skipRenderingHack = config::GdxSkipRenderingHack && frame + 1 < seekToFrame;
 	rend_enable_renderer(false);
 	inRollback = true;
 
@@ -297,6 +303,7 @@ static bool advance_frame(int)
 	ggpo_advance_frame(ggpoSession);
 
 	settings.aica.muteAudio = false;
+	settings.gdxsv.skipRenderingHack = false;
 	rend_enable_renderer(true);
 	inRollback = false;
 	_endOfFrame = false;
@@ -315,6 +322,7 @@ static bool advance_frame(int)
 static bool load_game_state(unsigned char *buffer, int len)
 {
 	INFO_LOG(NETWORK, "load_game_state");
+	ggpo::getCurrentFrame(&seekToFrame);
 
 	rend_start_rollback();
 	// FIXME dynarecs

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -665,19 +665,13 @@ static void gui_display_commands()
 	{
 		DisabledScope scope(gdxsv_is_online());
 		
-		if (!gdxsv_is_replaying() && ImGui::Button("Replays", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)) && !scope.isDisabled())
+		if (ImGui::Button("Replays", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)) && !scope.isDisabled())
 		{
 			gui_state = GuiState::GdxsvReplay;
 		}
 		if (gdxsv_is_online() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 		{
 			ImGui::SetTooltip("Please disconnect from the Gdxsv server first.");
-		}
-		
-		if (gdxsv_is_replaying() && ImGui::Button("Stop Replay", ScaledVec2(300, 50) + ImVec2(ImGui::GetStyle().ColumnsMinSpacing + ImGui::GetStyle().FramePadding.x * 2 - 1, 0)))
-		{
-			gui_state = GuiState::Closed;
-			gdxsv_stop_replay();
 		}
 	}
 	

--- a/core/types.h
+++ b/core/types.h
@@ -309,6 +309,12 @@ struct settings_t
 		int drivingSimSlave;
 	} naomi;
 
+	struct
+	{
+		int disk;
+		bool skipRenderingHack;
+	} gdxsv;
+
 	bool disableRenderer;
 };
 


### PR DESCRIPTION
##### Before (3.5ms/fr)
```
01:07:514 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 650[ms] (3.61[ms/fr]) 3956->4136(180 keys)
01:08:282 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 644[ms] (3.58[ms/fr]) 4146->4326(180 keys)
01:09:258 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 636[ms] (3.53[ms/fr]) 4349->4529(180 keys)
01:10:074 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 626[ms] (3.48[ms/fr]) 4543->4723(180 keys)
01:11:037 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 639[ms] (3.55[ms/fr]) 4745->4925(180 keys)
```

##### SkipRendering Hack (2.8ms/fr)
```
00:27:951 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 493[ms] (2.74[ms/fr]) 1507->1687(180 keys)
00:28:599 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 490[ms] (2.72[ms/fr]) 1699->1879(180 keys)
00:29:272 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 500[ms] (2.78[ms/fr]) 1892->2072(180 keys)
00:29:926 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 496[ms] (2.76[ms/fr]) 2084->2264(180 keys)
00:30:626 gdxsv\gdxsv_backend_replay.cpp:230 N[COMMON]: SomeFrameForward skipped 180[fr] in 493[ms] (2.74[ms/fr]) 2279->2459(180 keys)
```

##### SlowIdleLoopHack (2.9ms/fr)
```
00:28:390 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 532[ms] (2.96[ms/fr]) 3085->3265(180 keys)
00:29:036 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 506[ms] (2.81[ms/fr]) 3276->3456(180 keys)
00:29:671 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 514[ms] (2.86[ms/fr]) 3466->3646(180 keys)
00:30:252 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 491[ms] (2.73[ms/fr]) 3654->3834(180 keys)
00:30:913 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 507[ms] (2.82[ms/fr]) 3846->4026(180 keys)
```

##### SkipRendering + SlowIdleLoopHack (1.5ms/fr)
```
00:25:521 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 254[ms] (1.41[ms/fr]) 2714->2894(180 keys)
00:26:053 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 260[ms] (1.44[ms/fr]) 2913->3093(180 keys)
00:26:569 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 293[ms] (1.63[ms/fr]) 3109->3289(180 keys)
00:27:089 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 264[ms] (1.47[ms/fr]) 3307->3487(180 keys)
00:27:629 gdxsv\gdxsv_backend_replay.cpp:228 N[COMMON]: SomeFrameForward skipped 180[fr] in 285[ms] (1.58[ms/fr]) 3505->3685(180 keys)
```