### PR TITLE
GGPO Tuning; TimeSync, Predictions

### DIFF
--- a/core/deps/ggpo/lib/ggpo/backends/p2p.cpp
+++ b/core/deps/ggpo/lib/ggpo/backends/p2p.cpp
@@ -9,7 +9,7 @@
 #include <chrono>
 #include <thread>
 
-static const int RECOMMENDATION_INTERVAL           = 180;
+static const int RECOMMENDATION_INTERVAL           = 30;
 static const int DEFAULT_DISCONNECT_TIMEOUT        = 5000;
 static const int DEFAULT_DISCONNECT_NOTIFY_START   = 750;
 
@@ -25,6 +25,7 @@ Peer2PeerBackend::Peer2PeerBackend(GGPOSessionCallbacks *cb,
     _num_spectators(0),
     _input_size(input_size),
     _num_players(num_players),
+    _local_player_queue(-1),
     _next_spectator_frame(0),
     _disconnect_timeout(DEFAULT_DISCONNECT_TIMEOUT),
     _disconnect_notify_start(DEFAULT_DISCONNECT_NOTIFY_START),
@@ -123,7 +124,7 @@ Peer2PeerBackend::DoPoll(int timeout)
          // next connection quality report
          int current_frame = _sync.GetFrameCount();
          for (int i = 0; i < _num_players; i++) {
-            _endpoints[i].SetLocalFrameNumber(current_frame);
+            _endpoints[i].SetLocalFrameNumber(current_frame, _sync.GetFrameDelay(_local_player_queue));
          }
 
          int total_min_confirmed;
@@ -273,6 +274,8 @@ Peer2PeerBackend::AddPlayer(GGPOPlayer *player,
    }
 
    if (player->type == GGPO_PLAYERTYPE_LOCAL) {
+       ASSERT(_local_player_queue == -1);
+       _local_player_queue = queue;
        for (int q = 0; q < _num_players; q++) {
            _endpoints[q].SetLocalPlayerQueue(queue);
        }
@@ -565,7 +568,7 @@ Peer2PeerBackend::GetNetworkStats(GGPONetworkStats *stats, GGPOPlayerHandle play
 
    memset(stats, 0, sizeof *stats);
    _endpoints[queue].GetNetworkStats(stats);
-   stats->sync.predicted_frames = _sync.GetPredictedFrames();
+   stats->sync.predicted_frames = _sync.GetPredictedFrames(queue);
 
    return GGPO_OK;
 }

--- a/core/deps/ggpo/lib/ggpo/backends/p2p.h
+++ b/core/deps/ggpo/lib/ggpo/backends/p2p.h
@@ -69,6 +69,7 @@ protected:
 
    bool                  _synchronizing;
    int                   _num_players;
+   int                   _local_player_queue;
    int                   _next_recommended_sleep;
 
    int                   _next_spectator_frame;

--- a/core/deps/ggpo/lib/ggpo/backends/spectator.cpp
+++ b/core/deps/ggpo/lib/ggpo/backends/spectator.cpp
@@ -161,7 +161,7 @@ SpectatorBackend::OnUdpProtocolEvent(UdpProtocol::Event &evt)
    	  {
    		  GameInput& input = evt.u.input.input;
 
-   		  _host.SetLocalFrameNumber(input.frame);
+   		  _host.SetLocalFrameNumber(input.frame, 0);
    		  _host.SendInputAck();
    		  _inputs[input.frame % SPECTATOR_FRAME_BUFFER_SIZE] = input;
    	  }

--- a/core/deps/ggpo/lib/ggpo/input_queue.h
+++ b/core/deps/ggpo/lib/ggpo/input_queue.h
@@ -25,6 +25,7 @@ public:
    int GetLength() { return _length; }
 
    void SetFrameDelay(int delay) { _frame_delay = delay; }
+   int GetFrameDelay() { return _frame_delay; }
    void ResetPrediction(int frame);
    void DiscardConfirmedFrames(int frame);
    bool GetConfirmedInput(int frame, GameInput *input);

--- a/core/deps/ggpo/lib/ggpo/network/udp_proto.cpp
+++ b/core/deps/ggpo/lib/ggpo/network/udp_proto.cpp
@@ -757,7 +757,7 @@ UdpProtocol::GetNetworkStats(struct GGPONetworkStats *s)
 }
 
 void
-UdpProtocol::SetLocalFrameNumber(int localFrame)
+UdpProtocol::SetLocalFrameNumber(int localFrame, int input_delay)
 {
    /*
     * Estimate which frame the other guy is one by looking at the
@@ -772,7 +772,7 @@ UdpProtocol::SetLocalFrameNumber(int localFrame)
     * it means they'll have to predict more often and our moves will
     * pop more frequenetly.
     */
-   _local_frame_advantage = remoteFrame - localFrame;
+   _local_frame_advantage = remoteFrame - (localFrame + input_delay);
 }
 
 void

--- a/core/deps/ggpo/lib/ggpo/network/udp_proto.h
+++ b/core/deps/ggpo/lib/ggpo/network/udp_proto.h
@@ -89,7 +89,7 @@ public:
    void GetNetworkStats(struct GGPONetworkStats *stats);
    bool GetEvent(UdpProtocol::Event &e);
    void GGPONetworkStats(Stats *stats);
-   void SetLocalFrameNumber(int num);
+   void SetLocalFrameNumber(int num, int input_delay);
    void SetLocalPlayerQueue(int queue);
    int RecommendFrameDelay();
    void SetVerificationData(const void *verification, int verification_size) {

--- a/core/deps/ggpo/lib/ggpo/sync.cpp
+++ b/core/deps/ggpo/lib/ggpo/sync.cpp
@@ -57,7 +57,7 @@ Sync::SetLastConfirmedFrame(int frame)
 bool
 Sync::AddLocalInput(int queue, GameInput &input)
 {
-   int frames_behind = _framecount - _last_confirmed_frame; 
+   int frames_behind = _framecount - _last_confirmed_frame - _input_queues[queue].GetFrameDelay();
    if (_framecount >= _max_prediction_frames && frames_behind >= _max_prediction_frames) {
       Log("Rejecting input from emulator: reached prediction barrier.");
       return false;
@@ -274,6 +274,13 @@ Sync::CheckSimulationConsistency(int *seekTo)
    *seekTo = first_incorrect;
    return false;
 }
+
+int
+Sync::GetFrameDelay(int queue)
+{
+   return _input_queues[queue].GetFrameDelay();
+}
+
 
 void
 Sync::SetFrameDelay(int queue, int delay)

--- a/core/deps/ggpo/lib/ggpo/sync.h
+++ b/core/deps/ggpo/lib/ggpo/sync.h
@@ -15,7 +15,7 @@
 #include "ring_buffer.h"
 #include "network/udp_msg.h"
 
-#define MAX_PREDICTION_FRAMES    8
+#define MAX_PREDICTION_FRAMES    6
 
 class SyncTestBackend;
 
@@ -46,6 +46,7 @@ public:
 
    void SetLastConfirmedFrame(int frame);
    void SetFrameDelay(int queue, int delay);
+   int GetFrameDelay(int queue);
    bool AddLocalInput(int queue, GameInput &input);
    void AddRemoteInput(int queue, GameInput &input);
    int GetConfirmedInputs(void *values, int size, int frame);
@@ -57,7 +58,7 @@ public:
 
    int GetFrameCount() { return _framecount; }
    bool InRollback() { return _rollingback; }
-   int GetPredictedFrames() { return _framecount - _last_confirmed_frame; }
+   int GetPredictedFrames(int queue) { return _framecount - _last_confirmed_frame - GetFrameDelay(queue); }
 
    bool GetEvent(Event &e);
 

--- a/core/deps/ggpo/lib/ggpo/timesync.cpp
+++ b/core/deps/ggpo/lib/ggpo/timesync.cpp
@@ -12,7 +12,6 @@ TimeSync::TimeSync()
 {
    memset(_local, 0, sizeof(_local));
    memset(_remote, 0, sizeof(_remote));
-   _next_prediction = FRAME_WINDOW_SIZE * 3;
 }
 
 TimeSync::~TimeSync()
@@ -51,11 +50,9 @@ TimeSync::recommend_frame_wait_duration(bool require_idle_input)
    // See if someone should take action.  The person furthest ahead
    // needs to slow down so the other user can catch up.
    // Only do this if both clients agree on who's ahead!!
-   /*
    if (advantage >= radvantage) {
       return 0;
    }
-   */
 
    // Both clients agree that we're the one ahead.  Split
    // the difference between the two to figure out how long to

--- a/core/deps/ggpo/lib/ggpo/timesync.h
+++ b/core/deps/ggpo/lib/ggpo/timesync.h
@@ -11,9 +11,9 @@
 #include "game_input.h"
 #include "ggpo_types.h"
 
-#define FRAME_WINDOW_SIZE           40
+#define FRAME_WINDOW_SIZE           10
 #define MIN_UNIQUE_FRAMES           10
-#define MIN_FRAME_ADVANTAGE          3
+#define MIN_FRAME_ADVANTAGE          2
 #define MAX_FRAME_ADVANTAGE          9
 
 class TimeSync {

--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -1057,14 +1057,11 @@ void drawNetworkStat(const proto::P2PMatching& matching) {
 	ImGui::Text(ts.c_str());
 
 	// Predicted Frames
-	if (stats[me].sync.predicted_frames >= 7)
+	if (stats[me].sync.predicted_frames >= 5)
 		// red
-		ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(1, 0, 0, 1));
-	else if (stats[me].sync.predicted_frames >= 5)
-		// yellow
-		ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(.9f, .9f, .1f, 1));
+		ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(.6, .2f, .2f, 1));
 	ImGui::Text("Predicted");
-	ImGui::ProgressBar(stats[me].sync.predicted_frames / 7.f, ImVec2(-1, 10.f * settings.display.uiScale), "");
+	ImGui::ProgressBar(stats[me].sync.predicted_frames / 5.f, ImVec2(-1, 10.f * settings.display.uiScale), "");
 	if (stats[me].sync.predicted_frames >= 5) ImGui::PopStyleColor();
 
 	for (int i = 0; i < matching.users_size(); i++) {

--- a/core/network/ggpo.cpp
+++ b/core/network/ggpo.cpp
@@ -957,31 +957,31 @@ void displayStats()
 	ImGui::Begin("##ggpostats", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
 	ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(0.557f, 0.268f, 0.965f, 1.f));
 
+	{
+		ggpo_get_network_stats(ggpoSession, localPlayerNum, &stats);
+		// Frame Delay
+		ImGui::Text("Delay");
+		std::string delay = std::to_string(config::GGPODelay.get());
+		ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(delay.c_str()).x);
+		ImGui::Text("%s", delay.c_str());
+
+		// Predicted Frames
+		if (stats.sync.predicted_frames >= 7)
+			// red
+			ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(1, 0, 0, 1));
+		else if (stats.sync.predicted_frames >= 5)
+			// yellow
+			ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(.9f, .9f, .1f, 1));
+		ImGui::Text("Predicted");
+		ImGui::ProgressBar(stats.sync.predicted_frames / 7.f, ImVec2(-1, 10.f * settings.display.uiScale), "");
+		if (stats.sync.predicted_frames >= 5)
+			ImGui::PopStyleColor();
+	}
+
 	for (int i = 0; i < MAX_PLAYERS; i++) {
-		ggpo_get_network_stats(ggpoSession, playerHandles[i], &stats);
-
-		if (i == 0) {
-			// Frame Delay
-			ImGui::Text("Delay");
-			std::string delay = std::to_string(config::GGPODelay.get());
-			ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(delay.c_str()).x);
-			ImGui::Text("%s", delay.c_str());
-
-			// Predicted Frames
-			if (stats.sync.predicted_frames >= 7)
-				// red
-				ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(1, 0, 0, 1));
-			else if (stats.sync.predicted_frames >= 5)
-				// yellow
-				ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(.9f, .9f, .1f, 1));
-			ImGui::Text("Predicted");
-			ImGui::ProgressBar(stats.sync.predicted_frames / 7.f, ImVec2(-1, 10.f * settings.display.uiScale), "");
-			if (stats.sync.predicted_frames >= 5)
-				ImGui::PopStyleColor();
-		}
-
 		if (i == localPlayerNum) continue;
 		if (playerHandles[i] == 0) continue;
+		ggpo_get_network_stats(ggpoSession, playerHandles[i], &stats);
 
 		ImGui::Text("-- %dP --", i+1);
 
@@ -1197,6 +1197,12 @@ void gdxsvStartSession(const char* sessionCode, int me,
 		ggpo::remotePlayer = playerHandles[i];
 	}
 
+	if (getenv("GGPO_DELAY") != nullptr) {
+		const int v = atoi(getenv("GGPO_DELAY"));
+		if (0 <= v && v <= 64) {
+			config::GGPODelay.override(v);
+		}
+	}
 	ggpo_set_frame_delay(ggpoSession, localPlayer, config::GGPODelay.get());
 
 	DEBUG_LOG(NETWORK, "GGPO session started");

--- a/core/rend/mainui.cpp
+++ b/core/rend/mainui.cpp
@@ -138,7 +138,7 @@ void mainui_loop()
 		else
 			imguiDriver->present();
 
-		if (ggpo::active() && MainFrameCount % 60 == 0 && 0 < ggpo::timeSyncFrames) {
+		if (ggpo::active() && MainFrameCount % 5 == 0 && 0 < ggpo::timeSyncFrames) {
 			ggpo::timeSyncFrames.fetch_sub(1);
 			fixedFrequencyWait();
 		}


### PR DESCRIPTION
- Reduce max prediction frames to 6.
- Don't take DelayInput as prediction.
- Fast timesync.
- Remove negative timesync.
