### PR TITLE
macOS: Fix dangling reference / use-after-free

### DIFF
--- a/core/gdxsv/gdxsv_custom_texture_source.cpp
+++ b/core/gdxsv/gdxsv_custom_texture_source.cpp
@@ -87,7 +87,8 @@ bool GdxsvEmbedTextureSource::loadMap() {
 	if (GdxsvLanguage::Language() != GdxsvLanguage::Lang::Disabled) {
 		// Normal image files by language
 		if (!textures_path.empty()) {
-			hostfs::DirectoryTree tree(textures_path + GdxsvLanguage::TextureDirectoryName());
+			std::string localized_textures_path = textures_path + GdxsvLanguage::TextureDirectoryName();
+			hostfs::DirectoryTree tree(localized_textures_path);
 			for (const hostfs::FileInfo& item : tree) {
 				std::string extension = get_file_extension(item.name);
 				if (extension != "jpg" && extension != "jpeg" && extension != "png") continue;


### PR DESCRIPTION
`hostfs` does not own the `std::string`, so we can't pass rvalue