### PR TITLE
Frame pacing improvements and input optimization

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -110,6 +110,9 @@ Option<int> AnisotropicFiltering("rend.AnisotropicFiltering", 1);
 Option<int> TextureFiltering("rend.TextureFiltering", 0); // Default
 Option<bool> ThreadedRendering("rend.ThreadedRendering", true);
 Option<bool> DupeFrames("rend.DupeFrames", false);
+#ifdef _WIN32
+Option<bool> JoystickPolling("input.JoystickPolling", false);
+#endif
 Option<int> PerPixelLayers("rend.PerPixelLayers", 32);
 #ifdef TARGET_UWP
 Option<bool> NativeDepthInterpolation("rend.NativeDepthInterpolation", true);

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -470,6 +470,11 @@ extern Option<int> AnisotropicFiltering;
 extern Option<int> TextureFiltering; // 0: default, 1: force nearest, 2: force linear
 extern Option<bool> ThreadedRendering;
 extern Option<bool> DupeFrames;
+#ifdef _WIN32
+extern Option<bool> JoystickPolling;
+#else
+constexpr bool JoystickPolling = false;
+#endif
 extern Option<bool> NativeDepthInterpolation;
 extern Option<bool> EmulateFramebuffer;
 extern Option<int> FixedFrequency;

--- a/core/deps/implot/implot.cpp
+++ b/core/deps/implot/implot.cpp
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2023 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.17
+// ImPlot v0.18 WIP
 
 /*
 
@@ -31,7 +32,7 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about a old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all implot files.
 You can read releases logs https://github.com/epezent/implot/releases for more details.
 
-- 2023/08/20 (0.17) - ImPlotFlags_NoChild was removed as child windows are no longer needed to capture scroll. You can safely remove this flag if you were using it. 
+- 2023/08/20 (0.17) - ImPlotFlags_NoChild was removed as child windows are no longer needed to capture scroll. You can safely remove this flag if you were using it.
 - 2023/06/26 (0.15) - Various build fixes related to updates in Dear ImGui internals.
 - 2022/11/25 (0.15) - Make PlotText honor ImPlotItemFlags_NoFit.
 - 2022/06/19 (0.14) - The signature of ColormapScale has changed to accommodate a new ImPlotColormapScaleFlags parameter
@@ -96,7 +97,7 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 - 2020/09/07 (0.8)  - Plotting functions which accept a custom getter function pointer have been post-fixed with a G (e.g. PlotLineG)
 - 2020/09/06 (0.7)  - Several flags under ImPlotFlags and ImPlotAxisFlags were inverted (e.g. ImPlotFlags_Legend -> ImPlotFlags_NoLegend) so that the default flagset
                       is simply 0. This more closely matches ImGui's style and makes it easier to enable non-default but commonly used flags (e.g. ImPlotAxisFlags_Time).
-- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unecessary slow-down, and almost no one used it.
+- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unnecessary slow-down, and almost no one used it.
 - 2020/08/25 (0.5)  - ImPlotAxisFlags_Scientific was removed. Logarithmic axes automatically uses scientific notation.
 - 2020/08/17 (0.5)  - PlotText was changed so that text is centered horizontally and vertically about the desired point.
 - 2020/08/16 (0.5)  - An ImPlotContext must be explicitly created and destroyed now with `CreateContext` and `DestroyContext`. Previously, the context was statically initialized in this source file.
@@ -125,8 +126,11 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 
 */
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
+#ifndef IMGUI_DISABLE
 #include "implot_internal.h"
 
 #include <stdlib.h>
@@ -312,7 +316,7 @@ static const ImPlotStyleVarInfo GPlotStyleVarInfo[] =
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MajorGridSize)      }, // ImPlotStyleVar_MajorGridSize
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MinorGridSize)      }, // ImPlotStyleVar_MinorGridSize
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, PlotPadding)        }, // ImPlotStyleVar_PlotPadding
-    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LabelPadding)       }, // ImPlotStyleVar_LabelPaddine
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LabelPadding)       }, // ImPlotStyleVar_LabelPadding
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendPadding)      }, // ImPlotStyleVar_LegendPadding
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendInnerPadding) }, // ImPlotStyleVar_LegendInnerPadding
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendSpacing)      }, // ImPlotStyleVar_LegendSpacing
@@ -339,11 +343,16 @@ void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char *te
     if (!text_end)
         text_end = text_begin + strlen(text_begin);
     ImGuiContext& g = *GImGui;
+#ifdef IMGUI_HAS_TEXTURES
+    ImFontBaked* font = g.Font->GetFontBaked(g.FontSize);
+    const float scale = g.FontSize / font->Size;
+#else
     ImFont* font = g.Font;
+    const float scale = g.FontSize / font->FontSize;
+#endif
     // Align to be pixel perfect
     pos.x = ImFloor(pos.x);
     pos.y = ImFloor(pos.y);
-    const float scale = g.FontSize / font->FontSize;
     const char* s = text_begin;
     int chars_exp = (int)(text_end - s);
     int chars_rnd = 0;
@@ -604,10 +613,10 @@ bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2
     if (legend_rect.Max.y > outer_rect_pad.Max.y) {
         legend_rect.Max.y = outer_rect_pad.Max.y;
         clamped = true;
-    }    
+    }
     return clamped;
 }
-    
+
 int LegendSortingComp(const void* _a, const void* _b) {
     ImPlotItemGroup* items = GImPlot->SortItems;
     const int a = *(const int*)_a;
@@ -643,7 +652,7 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
     }
     // render
     for (int i = 0; i < num_items; ++i) {
-        const int idx           = indices[i];
+        const int idx           = ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_Reverse) ? indices[num_items - 1 - i] : indices[i];
         ImPlotItem* item        = items.GetLegendItem(idx);
         const char* label       = items.GetLegendLabel(idx);
         const float label_width = ImGui::CalcTextSize(label, nullptr, true).x;
@@ -947,20 +956,6 @@ tm* GetLocTime(const ImPlotTime& t, tm* ptm) {
 #endif
 }
 
-inline ImPlotTime MkTime(struct tm *ptm) {
-    if (GetStyle().UseLocalTime)
-        return MkLocTime(ptm);
-    else
-        return MkGmtTime(ptm);
-}
-
-inline tm* GetTime(const ImPlotTime& t, tm* ptm) {
-    if (GetStyle().UseLocalTime)
-        return GetLocTime(t,ptm);
-    else
-        return GetGmtTime(t,ptm);
-}
-
 ImPlotTime MakeTime(int year, int month, int day, int hour, int min, int sec, int us) {
     tm& Tm = GImPlot->Tm;
 
@@ -988,6 +983,12 @@ int GetYear(const ImPlotTime& t) {
     tm& Tm = GImPlot->Tm;
     GetTime(t, &Tm);
     return Tm.tm_year + 1900;
+}
+
+int GetMonth(const ImPlotTime& t) {
+    tm& Tm = GImPlot->Tm;
+    ImPlot::GetTime(t, &Tm);
+    return Tm.tm_mon;
 }
 
 ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count) {
@@ -1982,9 +1983,9 @@ bool UpdateInput(ImPlotPlot& plot) {
     if (any_hov && ImHasFlag(IO.KeyMods, gp.InputMap.ZoomMod)) {
 
         float zoom_rate = gp.InputMap.ZoomRate;
-        if (IO.MouseWheel == 0.0f) 
-            zoom_rate = 0;        
-        else if (IO.MouseWheel > 0) 
+        if (IO.MouseWheel == 0.0f)
+            zoom_rate = 0;
+        else if (IO.MouseWheel > 0)
             zoom_rate = (-zoom_rate) / (1.0f + (2.0f * zoom_rate));
         ImVec2 rect_size = plot.PlotRect.GetSize();
         float tx = ImRemap(IO.MousePos.x, plot.PlotRect.Min.x, plot.PlotRect.Max.x, 0.0f, 1.0f);
@@ -2451,7 +2452,7 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
         ResetCtxForNextPlot(GImPlot);
         return false;
     }
-    
+
     // setup items (or dont)
     if (gp.CurrentItems == nullptr)
         gp.CurrentItems = &plot.Items;
@@ -3047,7 +3048,7 @@ void EndPlot() {
         const bool legend_scrollable = ClampLegendRect(legend.RectClamped,
                                                         legend_out ? plot.FrameRect : plot.PlotRect,
                                                         legend_out ? gp.Style.PlotPadding : gp.Style.LegendPadding
-                                                        );       
+                                                        );
         const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
                                                     | ImGuiButtonFlags_PressedOnClick
                                                     | ImGuiButtonFlags_PressedOnDoubleClick
@@ -3058,21 +3059,25 @@ void EndPlot() {
         ImGui::KeepAliveID(plot.Items.ID);
         ImGui::ButtonBehavior(legend.RectClamped, plot.Items.ID, &legend.Hovered, &legend.Held, legend_button_flags);
         legend.Hovered = legend.Hovered || (ImGui::IsWindowHovered() && legend.RectClamped.Contains(IO.MousePos));
-       
+
         if (legend_scrollable) {
             if (legend.Hovered) {
                 ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, plot.Items.ID);
                 if (IO.MouseWheel != 0.0f) {
                     ImVec2 max_step = legend.Rect.GetSize() * 0.67f;
+#if IMGUI_VERSION_NUM < 19172
                     float font_size = ImGui::GetCurrentWindow()->CalcFontSize();
+#else
+                    float font_size = ImGui::GetCurrentWindow()->FontRefSize;
+#endif
                     float scroll_step = ImFloor(ImMin(2 * font_size, max_step.x));
                     legend.Scroll.x += scroll_step * IO.MouseWheel;
                     legend.Scroll.y += scroll_step * IO.MouseWheel;
                 }
-            }            
+            }
             const ImVec2 min_scroll_offset = legend.RectClamped.GetSize() - legend.Rect.GetSize();
             legend.Scroll.x = ImClamp(legend.Scroll.x, min_scroll_offset.x, 0.0f);
-            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);            
+            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);
             const ImVec2 scroll_offset = legend_horz ? ImVec2(legend.Scroll.x, 0) : ImVec2(0, legend.Scroll.y);
             ImVec2 legend_offset = legend.RectClamped.Min - legend.Rect.Min + scroll_offset;
             legend.Rect.Min += legend_offset;
@@ -3082,18 +3087,18 @@ void EndPlot() {
         }
 
         const ImU32 col_bg  = GetStyleColorU32(ImPlotCol_LegendBg);
-        const ImU32 col_bd  = GetStyleColorU32(ImPlotCol_LegendBorder);        
-        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);       
-        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);        
+        const ImU32 col_bd  = GetStyleColorU32(ImPlotCol_LegendBorder);
+        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);
+        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);
         bool legend_contextable = ShowLegendEntries(plot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
-                                && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);        
+                                && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);
         DrawList.AddRect(legend.RectClamped.Min, legend.RectClamped.Max, col_bd);
         ImGui::PopClipRect();
 
         // main ctx menu
         if (gp.OpenContextThisFrame && legend_contextable && !ImHasFlag(plot.Flags, ImPlotFlags_NoMenus))
-            ImGui::OpenPopup("##LegendContext");        
-        
+            ImGui::OpenPopup("##LegendContext");
+
         if (ImGui::BeginPopup("##LegendContext")) {
             ImGui::Text("Legend"); ImGui::Separator();
             if (ShowLegendContextMenu(legend, !ImHasFlag(plot.Flags, ImPlotFlags_NoLegend)))
@@ -3566,7 +3571,7 @@ void EndSubplots() {
         const ImVec2 legend_pos  = GetLocationPos(subplot.FrameRect, legend_size, legend.Location, gp.Style.PlotPadding);
         legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
         legend.RectClamped = legend.Rect;
-        const bool legend_scrollable = ClampLegendRect(legend.RectClamped,subplot.FrameRect, gp.Style.PlotPadding);    
+        const bool legend_scrollable = ClampLegendRect(legend.RectClamped,subplot.FrameRect, gp.Style.PlotPadding);
         const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
                                                     | ImGuiButtonFlags_PressedOnClick
                                                     | ImGuiButtonFlags_PressedOnDoubleClick
@@ -3577,21 +3582,25 @@ void EndSubplots() {
         ImGui::KeepAliveID(subplot.Items.ID);
         ImGui::ButtonBehavior(legend.RectClamped, subplot.Items.ID, &legend.Hovered, &legend.Held, legend_button_flags);
         legend.Hovered = legend.Hovered || (subplot.FrameHovered && legend.RectClamped.Contains(ImGui::GetIO().MousePos));
-        
+
         if (legend_scrollable) {
             if (legend.Hovered) {
                 ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, subplot.Items.ID);
                 if (IO.MouseWheel != 0.0f) {
                     ImVec2 max_step = legend.Rect.GetSize() * 0.67f;
+#if IMGUI_VERSION_NUM < 19172
                     float font_size = ImGui::GetCurrentWindow()->CalcFontSize();
+#else
+                    float font_size = ImGui::GetCurrentWindow()->FontRefSize;
+#endif
                     float scroll_step = ImFloor(ImMin(2 * font_size, max_step.x));
                     legend.Scroll.x += scroll_step * IO.MouseWheel;
                     legend.Scroll.y += scroll_step * IO.MouseWheel;
                 }
-            }                    
+            }
             const ImVec2 min_scroll_offset = legend.RectClamped.GetSize() - legend.Rect.GetSize();
             legend.Scroll.x = ImClamp(legend.Scroll.x, min_scroll_offset.x, 0.0f);
-            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);            
+            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);
             const ImVec2 scroll_offset = legend_horz ? ImVec2(legend.Scroll.x, 0) : ImVec2(0, legend.Scroll.y);
             ImVec2 legend_offset = legend.RectClamped.Min - legend.Rect.Min + scroll_offset;
             legend.Rect.Min += legend_offset;
@@ -3602,13 +3611,13 @@ void EndSubplots() {
 
         const ImU32 col_bg = GetStyleColorU32(ImPlotCol_LegendBg);
         const ImU32 col_bd = GetStyleColorU32(ImPlotCol_LegendBorder);
-        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);       
-        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);        
+        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);
+        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);
         bool legend_contextable = ShowLegendEntries(subplot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
                                 && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);
         DrawList.AddRect(legend.RectClamped.Min, legend.RectClamped.Max, col_bd);
         ImGui::PopClipRect();
-        
+
         if (legend_contextable && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoMenus) && ImGui::GetIO().MouseReleased[gp.InputMap.Menu])
             ImGui::OpenPopup("##LegendContext");
         if (ImGui::BeginPopup("##LegendContext")) {
@@ -3624,7 +3633,7 @@ void EndSubplots() {
     // remove items
     if (gp.CurrentItems == &subplot.Items)
         gp.CurrentItems = nullptr;
-    // reset the plot items for the next frame (TODO: put this elswhere)
+    // reset the plot items for the next frame (TODO: put this elsewhere)
     for (int i = 0; i < subplot.Items.GetItemCount(); ++i) {
         subplot.Items.GetItemByIndex(i)->SeenThisFrame = false;
     }
@@ -4093,31 +4102,34 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
 
     bool modified = false;
     bool clicked = false, hovered = false, held = false;
-    ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
 
-    ImGui::KeepAliveID(id);
-    if (input) {
-        // middle point
-        clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
-        if (out_clicked) *out_clicked = clicked;
-        if (out_hovered) *out_hovered = hovered;
-        if (out_held)    *out_held    = held;
-    }
-
-    if ((hovered || held) && show_curs)
-        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
-    if (held && ImGui::IsMouseDragging(0)) {
-        for (int i = 0; i < 4; ++i) {
-            ImPlotPoint pp = PixelsToPlot(p[i] + ImGui::GetIO().MouseDelta,IMPLOT_AUTO,IMPLOT_AUTO);
-            *y[i] = pp.y;
-            *x[i] = pp.x;
+    const bool is_movable = *x_min != *x_max || *y_min != *y_max;
+    if (is_movable) {
+        ImGui::KeepAliveID(id);
+        if (input) {
+            // middle point
+            ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
+            clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+            if (out_clicked) *out_clicked = clicked;
+            if (out_hovered) *out_hovered = hovered;
+            if (out_held)    *out_held    = held;
         }
-        modified = true;
+
+        if ((hovered || held) && show_curs)
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
+        if (held && ImGui::IsMouseDragging(0)) {
+            for (int i = 0; i < 4; ++i) {
+                ImPlotPoint pp = PixelsToPlot(p[i] + ImGui::GetIO().MouseDelta,IMPLOT_AUTO,IMPLOT_AUTO);
+                *y[i] = pp.y;
+                *x[i] = pp.x;
+            }
+            modified = true;
+        }
     }
 
     for (int i = 0; i < 4; ++i) {
         // points
-        b_rect = ImRect(p[i].x-DRAG_GRAB_HALF_SIZE,p[i].y-DRAG_GRAB_HALF_SIZE,p[i].x+DRAG_GRAB_HALF_SIZE,p[i].y+DRAG_GRAB_HALF_SIZE);
+        ImRect b_rect(p[i].x - DRAG_GRAB_HALF_SIZE, p[i].y - DRAG_GRAB_HALF_SIZE, p[i].x + DRAG_GRAB_HALF_SIZE, p[i].y + DRAG_GRAB_HALF_SIZE);
         ImGuiID p_id = id + i + 1;
         ImGui::KeepAliveID(p_id);
         if (input) {
@@ -5010,9 +5022,15 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             filter.Draw("Filter colors", ImGui::GetFontSize() * 16);
 
             static ImGuiColorEditFlags alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf;
+#if IMGUI_VERSION_NUM < 19173
             if (ImGui::RadioButton("Opaque", alpha_flags == ImGuiColorEditFlags_None))             { alpha_flags = ImGuiColorEditFlags_None; } ImGui::SameLine();
             if (ImGui::RadioButton("Alpha",  alpha_flags == ImGuiColorEditFlags_AlphaPreview))     { alpha_flags = ImGuiColorEditFlags_AlphaPreview; } ImGui::SameLine();
             if (ImGui::RadioButton("Both",   alpha_flags == ImGuiColorEditFlags_AlphaPreviewHalf)) { alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf; } ImGui::SameLine();
+#else
+            if (ImGui::RadioButton("Opaque", alpha_flags == ImGuiColorEditFlags_AlphaOpaque))      { alpha_flags = ImGuiColorEditFlags_AlphaOpaque; } ImGui::SameLine();
+            if (ImGui::RadioButton("Alpha",  alpha_flags == ImGuiColorEditFlags_None))             { alpha_flags = ImGuiColorEditFlags_None; } ImGui::SameLine();
+            if (ImGui::RadioButton("Both",   alpha_flags == ImGuiColorEditFlags_AlphaPreviewHalf)) { alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf; } ImGui::SameLine();
+#endif
             HelpMarker(
                 "In the color list:\n"
                 "Left-click on colored square to open color picker,\n"
@@ -5171,7 +5189,7 @@ void ShowUserGuide() {
     ImGui::Indent();
         ImGui::BulletText("Left-click drag on axis labels to pan an individual axis.");
     ImGui::Unindent();
-    ImGui::BulletText("Scroll in the plot area to zoom both X any Y axes.");
+    ImGui::BulletText("Scroll in the plot area to zoom both X and Y axes.");
     ImGui::Indent();
         ImGui::BulletText("Scroll on axis labels to zoom an individual axis.");
     ImGui::Unindent();
@@ -5203,7 +5221,7 @@ void ShowAxisMetrics(const ImPlotPlot& plot, const ImPlotAxis& axis) {
     ImGui::BulletText("Range: [%f,%f]",axis.Range.Min, axis.Range.Max);
     ImGui::BulletText("Pixels: %f", axis.PixelSize());
     ImGui::BulletText("Aspect: %f", axis.GetAspect());
-    ImGui::BulletText(axis.OrthoAxis == nullptr ? "OrtherAxis: NULL" : "OrthoAxis: 0x%08X", axis.OrthoAxis->ID);
+    ImGui::BulletText(axis.OrthoAxis == nullptr ? "OrthoAxis: NULL" : "OrthoAxis: 0x%08X", axis.OrthoAxis->ID);
     ImGui::BulletText("LinkedMin: %p", (void*)axis.LinkedMin);
     ImGui::BulletText("LinkedMax: %p", (void*)axis.LinkedMax);
     ImGui::BulletText("HasRange: %s", axis.HasRange ? "true" : "false");
@@ -5883,3 +5901,5 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
 #endif
 
 }  // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/core/deps/implot/implot.h
+++ b/core/deps/implot/implot.h
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2023 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.17
+// ImPlot v0.18 WIP
 
 // Table of Contents:
 //
@@ -46,6 +47,7 @@
 
 #pragma once
 #include "imgui.h"
+#ifndef IMGUI_DISABLE
 
 //-----------------------------------------------------------------------------
 // [SECTION] Macros and Defines
@@ -54,13 +56,15 @@
 // Define attributes of all API symbols declarations (e.g. for DLL under Windows)
 // Using ImPlot via a shared library is not recommended, because we don't guarantee
 // backward nor forward ABI compatibility and also function call overhead. If you
-// do use ImPlot as a DLL, be sure to call SetImGuiContext (see Miscellanous section).
+// do use ImPlot as a DLL, be sure to call SetImGuiContext (see Miscellaneous section).
 #ifndef IMPLOT_API
 #define IMPLOT_API
 #endif
 
 // ImPlot version string.
-#define IMPLOT_VERSION "0.17"
+#define IMPLOT_VERSION "0.18 WIP"
+// ImPlot version integer encoded as XYYZZ (X=major, YY=minor, ZZ=patch).
+#define IMPLOT_VERSION_NUM 1800
 // Indicates variable should deduced automatically.
 #define IMPLOT_AUTO -1
 // Special color used to indicate that a color should be deduced automatically.
@@ -122,14 +126,14 @@ enum ImAxis_ {
     ImAxis_Y1,     // enabled by default
     ImAxis_Y2,     // disabled by default
     ImAxis_Y3,     // disabled by default
-    // bookeeping
+    // bookkeeping
     ImAxis_COUNT
 };
 
 // Options for plots (see BeginPlot).
 enum ImPlotFlags_ {
     ImPlotFlags_None          = 0,       // default
-    ImPlotFlags_NoTitle       = 1 << 0,  // the plot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MyPlot")
+    ImPlotFlags_NoTitle       = 1 << 0,  // the plot title will not be displayed (titles are also hidden if preceded by double hashes, e.g. "##MyPlot")
     ImPlotFlags_NoLegend      = 1 << 1,  // the legend will not be displayed
     ImPlotFlags_NoMouseText   = 1 << 2,  // the mouse position, in plot coordinates, will not be displayed inside of the plot
     ImPlotFlags_NoInputs      = 1 << 3,  // the user will not be able to interact with the plot
@@ -168,7 +172,7 @@ enum ImPlotAxisFlags_ {
 // Options for subplots (see BeginSubplot)
 enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_None        = 0,       // default
-    ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
+    ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceded by double hashes, e.g. "##MySubplot")
     ImPlotSubplotFlags_NoLegend    = 1 << 1,  // the legend will not be displayed (only applicable if ImPlotSubplotFlags_ShareItems is enabled)
     ImPlotSubplotFlags_NoMenus     = 1 << 2,  // the user will not be able to open context menus with right-click
     ImPlotSubplotFlags_NoResize    = 1 << 3,  // resize splitters between subplot cells will be not be provided
@@ -191,6 +195,7 @@ enum ImPlotLegendFlags_ {
     ImPlotLegendFlags_Outside         = 1 << 4, // legend will be rendered outside of the plot area
     ImPlotLegendFlags_Horizontal      = 1 << 5, // legend entries will be displayed horizontally
     ImPlotLegendFlags_Sort            = 1 << 6, // legend entries will be displayed in alphabetical order
+    ImPlotLegendFlags_Reverse         = 1 << 7, // legend entries will be displayed in reverse order
 };
 
 // Options for mouse hover text (see SetupMouseText)
@@ -288,7 +293,8 @@ enum ImPlotInfLinesFlags_ {
 enum ImPlotPieChartFlags_ {
     ImPlotPieChartFlags_None         = 0,       // default
     ImPlotPieChartFlags_Normalize    = 1 << 10, // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
-    ImPlotPieChartFlags_IgnoreHidden = 1 << 11  // ignore hidden slices when drawing the pie chart (as if they were not there)
+    ImPlotPieChartFlags_IgnoreHidden = 1 << 11, // ignore hidden slices when drawing the pie chart (as if they were not there)
+    ImPlotPieChartFlags_Exploding    = 1 << 12  // Explode legend-hovered slice
 };
 
 // Flags for PlotHeatmap
@@ -303,7 +309,7 @@ enum ImPlotHistogramFlags_ {
     ImPlotHistogramFlags_Horizontal = 1 << 10, // histogram bars will be rendered horizontally (not supported by PlotHistogram2D)
     ImPlotHistogramFlags_Cumulative = 1 << 11, // each bin will contain its count plus the counts of all previous bins (not supported by PlotHistogram2D)
     ImPlotHistogramFlags_Density    = 1 << 12, // counts will be normalized, i.e. the PDF will be visualized, or the CDF will be visualized if Cumulative is also set
-    ImPlotHistogramFlags_NoOutliers = 1 << 13, // exclude values outside the specifed histogram range from the count toward normalizing and cumulative counts
+    ImPlotHistogramFlags_NoOutliers = 1 << 13, // exclude values outside the specified histogram range from the count toward normalizing and cumulative counts
     ImPlotHistogramFlags_ColMajor   = 1 << 14  // data will be read in column major order (not supported by PlotHistogram)
 };
 
@@ -353,7 +359,7 @@ enum ImPlotCol_ {
     ImPlotCol_LegendText,    // legend text color (defaults to ImPlotCol_InlayText)
     ImPlotCol_TitleText,     // plot title text color (defaults to ImGuiCol_Text)
     ImPlotCol_InlayText,     // color of text appearing inside of plots (defaults to ImGuiCol_Text)
-    ImPlotCol_AxisText,      // axis label and tick lables color (defaults to ImGuiCol_Text)
+    ImPlotCol_AxisText,      // axis label and tick labels color (defaults to ImGuiCol_Text)
     ImPlotCol_AxisGrid,      // axis grid color (defaults to 25% ImPlotCol_AxisText)
     ImPlotCol_AxisTick,      // axis tick color (defaults to AxisGrid)
     ImPlotCol_AxisBg,        // background color of axis hover region (defaults to transparent)
@@ -402,7 +408,7 @@ enum ImPlotStyleVar_ {
 enum ImPlotScale_ {
     ImPlotScale_Linear = 0, // default linear scale
     ImPlotScale_Time,       // date/time scale
-    ImPlotScale_Log10,      // base 10 logartithmic scale
+    ImPlotScale_Log10,      // base 10 logarithmic scale
     ImPlotScale_SymLog,     // symmetric log scale
 };
 
@@ -467,11 +473,11 @@ enum ImPlotBin_ {
 IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImPlotPoint {
     double x, y;
-    constexpr ImPlotPoint()                     : x(0.0), y(0.0) { }
-    constexpr ImPlotPoint(double _x, double _y) : x(_x), y(_y) { }
-    constexpr ImPlotPoint(const ImVec2& p)      : x((double)p.x), y((double)p.y) { }
-    double& operator[] (size_t idx)             { IM_ASSERT(idx == 0 || idx == 1); return ((double*)(void*)(char*)this)[idx]; }
-    double  operator[] (size_t idx) const       { IM_ASSERT(idx == 0 || idx == 1); return ((const double*)(const void*)(const char*)this)[idx]; }
+    IMPLOT_API constexpr ImPlotPoint()                     : x(0.0), y(0.0) { }
+    IMPLOT_API constexpr ImPlotPoint(double _x, double _y) : x(_x), y(_y) { }
+    IMPLOT_API constexpr ImPlotPoint(const ImVec2& p)      : x((double)p.x), y((double)p.y) { }
+    IMPLOT_API double& operator[] (size_t idx)             { IM_ASSERT(idx == 0 || idx == 1); return ((double*)(void*)(char*)this)[idx]; }
+    IMPLOT_API double  operator[] (size_t idx) const       { IM_ASSERT(idx == 0 || idx == 1); return ((const double*)(const void*)(const char*)this)[idx]; }
 #ifdef IMPLOT_POINT_CLASS_EXTRA
     IMPLOT_POINT_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h
                                  // to convert back and forth between your math types and ImPlotPoint.
@@ -482,25 +488,25 @@ IM_MSVC_RUNTIME_CHECKS_RESTORE
 // Range defined by a min/max value.
 struct ImPlotRange {
     double Min, Max;
-    constexpr ImPlotRange()                         : Min(0.0), Max(0.0) { }
-    constexpr ImPlotRange(double _min, double _max) : Min(_min), Max(_max) { }
-    bool Contains(double value) const               { return value >= Min && value <= Max;                      }
-    double Size() const                             { return Max - Min;                                         }
-    double Clamp(double value) const                { return (value < Min) ? Min : (value > Max) ? Max : value; }
+    IMPLOT_API constexpr ImPlotRange()                         : Min(0.0), Max(0.0) { }
+    IMPLOT_API constexpr ImPlotRange(double _min, double _max) : Min(_min), Max(_max) { }
+    IMPLOT_API bool Contains(double value) const               { return value >= Min && value <= Max;                      }
+    IMPLOT_API double Size() const                             { return Max - Min;                                         }
+    IMPLOT_API double Clamp(double value) const                { return (value < Min) ? Min : (value > Max) ? Max : value; }
 };
 
 // Combination of two range limits for X and Y axes. Also an AABB defined by Min()/Max().
 struct ImPlotRect {
     ImPlotRange X, Y;
-    constexpr ImPlotRect()                                                       : X(0.0,0.0), Y(0.0,0.0) { }
-    constexpr ImPlotRect(double x_min, double x_max, double y_min, double y_max) : X(x_min, x_max), Y(y_min, y_max) { }
-    bool Contains(const ImPlotPoint& p) const                                    { return Contains(p.x, p.y);                 }
-    bool Contains(double x, double y) const                                      { return X.Contains(x) && Y.Contains(y);     }
-    ImPlotPoint Size() const                                                     { return ImPlotPoint(X.Size(), Y.Size());    }
-    ImPlotPoint Clamp(const ImPlotPoint& p)                                      { return Clamp(p.x, p.y);                    }
-    ImPlotPoint Clamp(double x, double y)                                        { return ImPlotPoint(X.Clamp(x),Y.Clamp(y)); }
-    ImPlotPoint Min() const                                                      { return ImPlotPoint(X.Min, Y.Min);          }
-    ImPlotPoint Max() const                                                      { return ImPlotPoint(X.Max, Y.Max);          }
+    IMPLOT_API constexpr ImPlotRect()                                                       : X(0.0,0.0), Y(0.0,0.0) { }
+    IMPLOT_API constexpr ImPlotRect(double x_min, double x_max, double y_min, double y_max) : X(x_min, x_max), Y(y_min, y_max) { }
+    IMPLOT_API bool Contains(const ImPlotPoint& p) const                                    { return Contains(p.x, p.y);                 }
+    IMPLOT_API bool Contains(double x, double y) const                                      { return X.Contains(x) && Y.Contains(y);     }
+    IMPLOT_API ImPlotPoint Size() const                                                     { return ImPlotPoint(X.Size(), Y.Size());    }
+    IMPLOT_API ImPlotPoint Clamp(const ImPlotPoint& p)                                      { return Clamp(p.x, p.y);                    }
+    IMPLOT_API ImPlotPoint Clamp(double x, double y)                                        { return ImPlotPoint(X.Clamp(x),Y.Clamp(y)); }
+    IMPLOT_API ImPlotPoint Min() const                                                      { return ImPlotPoint(X.Min, Y.Min);          }
+    IMPLOT_API ImPlotPoint Max() const                                                      { return ImPlotPoint(X.Max, Y.Max);          }
 };
 
 // Plot style structure
@@ -643,7 +649,7 @@ IMPLOT_API void EndPlot();
 
 // Starts a subdivided plotting context. If the function returns true,
 // EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols]
-// times in  between the begining and end of the subplot context. Plots are
+// times in  between the beginning and end of the subplot context. Plots are
 // added in row major order.
 //
 // Example:
@@ -744,7 +750,7 @@ IMPLOT_API void SetupAxisTicks(ImAxis axis, const double* values, int n_ticks, c
 IMPLOT_API void SetupAxisTicks(ImAxis axis, double v_min, double v_max, int n_ticks, const char* const labels[]=nullptr, bool keep_default=false);
 // Sets an axis' scale using built-in options.
 IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotScale scale);
-// Sets an axis' scale using user supplied forward and inverse transfroms.
+// Sets an axis' scale using user supplied forward and inverse transforms.
 IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotTransform forward, ImPlotTransform inverse, void* data=nullptr);
 // Sets an axis' limits constraints.
 IMPLOT_API void SetupAxisLimitsConstraints(ImAxis axis, double v_min, double v_max);
@@ -774,7 +780,7 @@ IMPLOT_API void SetupFinish();
 // using a preceding button or slider widget to change the plot limits). In
 // this case, you can use the `SetNext` API below. While this is not as feature
 // rich as the Setup API, most common needs are provided. These functions can be
-// called anwhere except for inside of `Begin/EndPlot`. For example:
+// called anywhere except for inside of `Begin/EndPlot`. For example:
 
 // if (ImGui::Button("Center Plot"))
 //     ImPlot::SetNextPlotLimits(-1,1,-1,1);
@@ -804,7 +810,7 @@ IMPLOT_API void SetNextAxesToFit();
 // [SECTION] Plot Items
 //-----------------------------------------------------------------------------
 
-// The main plotting API is provied below. Call these functions between
+// The main plotting API is provided below. Call these functions between
 // Begin/EndPlot and after any Setup API calls. Each plots data on the current
 // x and y axes, which can be changed with `SetAxis/Axes`.
 //
@@ -829,7 +835,7 @@ IMPLOT_API void SetNextAxesToFit();
 //    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance
 //    cost, but probably not enough to worry about unless your data is very large. Examples:
 //
-//    ImPlotPoint MyDataGetter(void* data, int idx) {
+//    ImPlotPoint MyDataGetter(int idx, void* data) {
 //        MyData* my_data = (MyData*)data;
 //        ImPlotPoint p;
 //        p.x = my_data->GetTime(idx);
@@ -912,7 +918,11 @@ IMPLOT_TMP void PlotDigital(const char* label_id, const T* xs, const T* ys, int 
 IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotDigitalFlags flags=0);
 
 // Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
-IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1), ImPlotImageFlags flags=0);
+#ifdef IMGUI_HAS_TEXTURES
+IMPLOT_API void PlotImage(const char* label_id, ImTextureRef tex_ref, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& tint_col = ImVec4(1, 1, 1, 1), ImPlotImageFlags flags = 0);
+#else
+IMPLOT_API void PlotImage(const char* label_id, ImTextureID tex_ref, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1), ImPlotImageFlags flags=0);
+#endif
 
 // Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
 IMPLOT_API void PlotText(const char* text, double x, double y, const ImVec2& pix_offset=ImVec2(0,0), ImPlotTextFlags flags=0);
@@ -931,13 +941,13 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 // user interactions can be retrieved through the optional output parameters.
 
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable and resizeable rectangle.
-IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
 IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);
@@ -972,7 +982,7 @@ IMPLOT_API ImVec2 PlotToPixels(double x, double y, ImAxis x_axis = IMPLOT_AUTO, 
 
 // Get the current Plot position (top-left) in pixels.
 IMPLOT_API ImVec2 GetPlotPos();
-// Get the curent Plot size in pixels.
+// Get the current Plot size in pixels.
 IMPLOT_API ImVec2 GetPlotSize();
 
 // Returns the mouse position in x,y coordinates of the current plot. Passing IMPLOT_AUTO uses the current axes.
@@ -1078,7 +1088,7 @@ IMPLOT_API void EndDragDropSource();
 //        manually set these colors to whatever you like, and further can Push/Pop
 //        them around individual plots for plot-specific styling (e.g. coloring axes).
 
-// Provides access to plot style structure for permanant modifications to colors, sizes, etc.
+// Provides access to plot style structure for permanent modifications to colors, sizes, etc.
 IMPLOT_API ImPlotStyle& GetStyle();
 
 // Style plot colors for current ImGui style (default).
@@ -1185,11 +1195,11 @@ IMPLOT_API ImVec4 SampleColormap(float t, ImPlotColormap cmap = IMPLOT_AUTO);
 IMPLOT_API void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0), const char* format = "%g", ImPlotColormapScaleFlags flags = 0, ImPlotColormap cmap = IMPLOT_AUTO);
 // Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1].
 IMPLOT_API bool ColormapSlider(const char* label, float* t, ImVec4* out = nullptr, const char* format = "", ImPlotColormap cmap = IMPLOT_AUTO);
-// Shows a button with a colormap gradient brackground.
+// Shows a button with a colormap gradient background.
 IMPLOT_API bool ColormapButton(const char* label, const ImVec2& size = ImVec2(0,0), ImPlotColormap cmap = IMPLOT_AUTO);
 
 // When items in a plot sample their color from a colormap, the color is cached and does not change
-// unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
+// unless explicitly overridden. Therefore, if you change the colormap after the item has already been plotted,
 // item colors will NOT update. If you need item colors to resample the new colormap, then use this
 // function to bust the cached colors. If #plot_title_id is nullptr, then every item in EVERY existing plot
 // will be cache busted. Otherwise only the plot specified by #plot_title_id will be busted. For the
@@ -1201,7 +1211,7 @@ IMPLOT_API void BustColorCache(const char* plot_title_id = nullptr);
 // [SECTION] Input Mapping
 //-----------------------------------------------------------------------------
 
-// Provides access to input mapping structure for permanant modifications to controls for pan, select, etc.
+// Provides access to input mapping structure for permanent modifications to controls for pan, select, etc.
 IMPLOT_API ImPlotInputMap& GetInputMap();
 
 // Default input mapping: pan = LMB drag, box select = RMB drag, fit = LMB double click, context menu = RMB click, zoom = scroll.
@@ -1294,4 +1304,5 @@ IMPLOT_DEPRECATED( IMPLOT_API bool BeginPlot(const char* title_id,
 
 } // namespace ImPlot
 
-#endif
+#endif // #ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#endif // #ifndef IMGUI_DISABLE

--- a/core/deps/implot/implot_internal.h
+++ b/core/deps/implot/implot_internal.h
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2023 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.17
+// ImPlot v0.18 WIP
 
 // You may use this file to debug, understand or extend ImPlot features but we
 // don't provide any guarantee of forward compatibility!
@@ -31,13 +32,13 @@
 
 #pragma once
 
-#include <time.h>
-#include "imgui_internal.h"
-
 #ifndef IMPLOT_VERSION
 #error Must include implot.h before implot_internal.h
 #endif
 
+#ifndef IMGUI_DISABLE
+#include <time.h>
+#include "imgui_internal.h"
 
 // Support for pre-1.84 versions. ImPool's GetSize() -> GetBufSize()
 #if (IMGUI_VERSION_NUM < 18303)
@@ -51,7 +52,7 @@
 // Constants can be changed unless stated otherwise. We may move some of these
 // to ImPlotStyleVar_ over time.
 
-// Mimimum allowable timestamp value 01/01/1970 @ 12:00am (UTC) (DO NOT DECREASE THIS)
+// Minimum allowable timestamp value 01/01/1970 @ 12:00am (UTC) (DO NOT DECREASE THIS)
 #define IMPLOT_MIN_TIME  0
 // Maximum allowable timestamp value 01/01/3000 @ 12:00am (UTC) (DO NOT INCREASE THIS)
 #define IMPLOT_MAX_TIME  32503680000
@@ -198,7 +199,7 @@ static inline ImU32 ImMixU32(ImU32 a, ImU32 b, ImU32 s) {
 #endif
 }
 
-// Lerp across an array of 32-bit collors given t in [0.0 1.0]
+// Lerp across an array of 32-bit colors given t in [0.0 1.0]
 static inline ImU32 ImLerpU32(const ImU32* colors, int size, float t) {
     int i1 = (int)((size - 1 ) * t);
     int i2 = i1 + 1;
@@ -420,6 +421,7 @@ struct ImPlotColormapData {
 // ImPlotPoint with positive/negative error values
 struct ImPlotPointError {
     double X, Y, Neg, Pos;
+    ImPlotPointError() { X = 0; Y = 0; Neg = 0; Pos = 0; }
     ImPlotPointError(double x, double y, double neg, double pos) {
         X = x; Y = y; Neg = neg; Pos = pos;
     }
@@ -486,6 +488,14 @@ struct ImPlotTag {
     ImU32  ColorBg;
     ImU32  ColorFg;
     int    TextOffset;
+
+    ImPlotTag() {
+        Axis       = 0;
+        Value      = 0;
+        ColorBg    = 0;
+        ColorFg    = 0;
+        TextOffset = 0;
+    }
 };
 
 struct ImPlotTagCollection {
@@ -539,6 +549,17 @@ struct ImPlotTick
     bool   ShowLabel;
     int    Level;
     int    Idx;
+
+    ImPlotTick() {
+        PlotPos      = 0;
+        PixelPos     = 0;
+        LabelSize    = ImVec2(0,0);
+        TextOffset   = -1;
+        Major        = false;
+        ShowLabel    = false;
+        Level        = 0;
+        Idx          = -1;
+    }
 
     ImPlotTick(double value, bool major, int level, bool show_label) {
         PixelPos     = 0;
@@ -1417,7 +1438,7 @@ IMPLOT_API ImVec2 GetLocationPos(const ImRect& outer_rect, const ImVec2& inner_s
 // Calculates the bounding box size of a legend _before_ clipping.
 IMPLOT_API ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& spacing, bool vertical);
 // Clips calculated legend size
-IMPLOT_API bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2& pad);      
+IMPLOT_API bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2& pad);
 // Renders legend entries into a bounding box
 IMPLOT_API bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, bool vertical, ImDrawList& DrawList);
 // Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window! This is not thoroughly tested nor scrollable!).
@@ -1564,11 +1585,24 @@ IMPLOT_API tm* GetLocTime(const ImPlotTime& t, tm* ptm);
 // NB: The following functions only work if there is a current ImPlotContext because the
 // internal tm struct is owned by the context! They are aware of ImPlotStyle.UseLocalTime.
 
+// // Make a UNIX timestamp from a tm struct according to the current ImPlotStyle.UseLocalTime setting.
+static inline ImPlotTime MkTime(struct tm *ptm) {
+    if (GetStyle().UseLocalTime) return MkLocTime(ptm);
+    else                         return MkGmtTime(ptm);
+}
+// Get a tm struct from a UNIX timestamp according to the current ImPlotStyle.UseLocalTime setting.
+static inline tm* GetTime(const ImPlotTime& t, tm* ptm) {
+    if (GetStyle().UseLocalTime) return GetLocTime(t,ptm);
+    else                         return GetGmtTime(t,ptm);
+}
+
 // Make a timestamp from time components.
 // year[1970-3000], month[0-11], day[1-31], hour[0-23], min[0-59], sec[0-59], us[0,999999]
 IMPLOT_API ImPlotTime MakeTime(int year, int month = 0, int day = 1, int hour = 0, int min = 0, int sec = 0, int us = 0);
 // Get year component from timestamp [1970-3000]
 IMPLOT_API int GetYear(const ImPlotTime& t);
+// Get month component from timestamp [0-11]
+IMPLOT_API int GetMonth(const ImPlotTime& t);
 
 // Adds or subtracts time from a timestamp. #count > 0 to add, < 0 to subtract.
 IMPLOT_API ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count);
@@ -1580,6 +1614,11 @@ IMPLOT_API ImPlotTime CeilTime(const ImPlotTime& t, ImPlotTimeUnit unit);
 IMPLOT_API ImPlotTime RoundTime(const ImPlotTime& t, ImPlotTimeUnit unit);
 // Combines the date of one timestamp with the time-of-day of another timestamp.
 IMPLOT_API ImPlotTime CombineDateTime(const ImPlotTime& date_part, const ImPlotTime& time_part);
+
+// Get the current time as a timestamp.
+static inline ImPlotTime Now() { return ImPlotTime::FromDouble((double)time(nullptr)); }
+// Get the current date as a timestamp.
+static inline ImPlotTime Today() { return ImPlot::FloorTime(Now(), ImPlotTimeUnit_Day); }
 
 // Formats the time part of timestamp t into a buffer according to #fmt
 IMPLOT_API int FormatTime(const ImPlotTime& t, char* buffer, int size, ImPlotTimeFmt fmt, bool use_24_hr_clk);
@@ -1661,9 +1700,11 @@ static inline int Formatter_Time(double, char* buff, int size, void* data) {
 // [SECTION] Locator
 //------------------------------------------------------------------------------
 
-void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
 
 } // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/core/deps/implot/implot_items.cpp
+++ b/core/deps/implot/implot_items.cpp
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2023 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.17
+// ImPlot v0.18 WIP
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
+#ifndef IMGUI_DISABLE
 #include "implot_internal.h"
 
 //-----------------------------------------------------------------------------
@@ -94,7 +98,7 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
     #define IMPLOT_NUMERIC_TYPES (ImS8)(ImU8)(ImS16)(ImU16)(ImS32)(ImU32)(ImS64)(ImU64)(float)(double)
 #endif
 
-// CALL_INSTANTIATE_FOR_NUMERIC_TYPES will duplicate the template instantion code `INSTANTIATE_MACRO(T)` on supported types.
+// CALL_INSTANTIATE_FOR_NUMERIC_TYPES will duplicate the template instantiation code `INSTANTIATE_MACRO(T)` on supported types.
 #define _CAT(x, y) _CAT_(x, y)
 #define _CAT_(x,y) x ## y
 #define _INSTANTIATE_FOR_NUMERIC_TYPES(chain) _CAT(_INSTANTIATE_FOR_NUMERIC_TYPES_1 chain, _END)
@@ -2197,20 +2201,53 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 // [SECTION] PlotPieChart
 //-----------------------------------------------------------------------------
 
-IMPLOT_INLINE void RenderPieSlice(ImDrawList& draw_list, const ImPlotPoint& center, double radius, double a0, double a1, ImU32 col) {
+IMPLOT_INLINE void RenderPieSlice(ImDrawList& draw_list, const ImPlotPoint& center, double radius, double a0, double a1, ImU32 col, bool detached = false) {
     const float resolution = 50 / (2 * IM_PI);
     ImVec2 buffer[52];
-    buffer[0] = PlotToPixels(center,IMPLOT_AUTO,IMPLOT_AUTO);
+
     int n = ImMax(3, (int)((a1 - a0) * resolution));
     double da = (a1 - a0) / (n - 1);
     int i = 0;
-    for (; i < n; ++i) {
-        double a = a0 + i * da;
-        buffer[i + 1] = PlotToPixels(center.x + radius * cos(a), center.y + radius * sin(a),IMPLOT_AUTO,IMPLOT_AUTO);
+
+    if (detached) {
+        const double offset = 0.08; // Offset of the detached slice
+        const double width_scale = 0.95; // Scale factor for the width of the detached slice
+
+        double a_mid = (a0 + a1) / 2;
+        double new_a0 = a_mid - (a1 - a0) * width_scale / 2;
+        double new_a1 = a_mid + (a1 - a0) * width_scale / 2;
+        double new_da = (new_a1 - new_a0) / (n - 1);
+
+        ImPlotPoint offsetCenter(center.x + offset * cos(a_mid), center.y + offset * sin(a_mid));
+
+        // Start point (center of the offset)
+        buffer[0] = PlotToPixels(offsetCenter, IMPLOT_AUTO, IMPLOT_AUTO);
+
+        for (; i < n; ++i) {
+            double a = new_a0 + i * new_da;
+            buffer[i + 1] = PlotToPixels(
+                offsetCenter.x + (radius + offset/2) * cos(a),
+                offsetCenter.y + (radius + offset/2) * sin(a),
+                IMPLOT_AUTO, IMPLOT_AUTO
+            );
+        }
+
+    } else {
+        buffer[0] = PlotToPixels(center, IMPLOT_AUTO, IMPLOT_AUTO);
+        for (; i < n; ++i) {
+            double a = a0 + i * da;
+            buffer[i + 1] = PlotToPixels(
+                center.x + radius * cos(a),
+                center.y + radius * sin(a),
+                IMPLOT_AUTO, IMPLOT_AUTO);
+        }
     }
-    buffer[i+1] = buffer[0];
+    // Close the shape
+    buffer[i + 1] = buffer[0];
+
     // fill
-    draw_list.AddConvexPolyFilled(buffer, n + 1, col);
+    draw_list.AddConvexPolyFilled(buffer, n + 2, col);
+
     // border (for AA)
     draw_list.AddPolyline(buffer, n + 2, col, 0, 2.0f);
 }
@@ -2243,32 +2280,32 @@ double PieChartSum(const T* values, int count, bool ignore_hidden) {
 template <typename T>
 void PlotPieChartEx(const char* const label_ids[], const T* values, int count, ImPlotPoint center, double radius, double angle0, ImPlotPieChartFlags flags) {
     ImDrawList& draw_list  = *GetPlotDrawList();
-    
+
     const bool ignore_hidden = ImHasFlag(flags, ImPlotPieChartFlags_IgnoreHidden);
     const double sum         = PieChartSum(values, count, ignore_hidden);
     const bool normalize     = ImHasFlag(flags, ImPlotPieChartFlags_Normalize) || sum > 1.0;
-    
+
     double a0 = angle0 * 2 * IM_PI / 360.0;
     double a1 = angle0 * 2 * IM_PI / 360.0;
     ImPlotPoint Pmin = ImPlotPoint(center.x - radius, center.y - radius);
     ImPlotPoint Pmax = ImPlotPoint(center.x + radius, center.y + radius);
     for (int i = 0; i < count; ++i) {
         ImPlotItem* item = GetItem(label_ids[i]);
-
         const double percent = normalize ? (double)values[i] / sum : (double)values[i];
         const bool skip      = sum <= 0.0 || (ignore_hidden && item != nullptr && !item->Show);
         if (!skip)
             a1 = a0 + 2 * IM_PI * percent;
 
         if (BeginItemEx(label_ids[i], FitterRect(Pmin, Pmax))) {
+            const bool hovered = ImPlot::IsLegendEntryHovered(label_ids[i]) && ImHasFlag(flags, ImPlotPieChartFlags_Exploding);
             if (sum > 0.0) {
                 ImU32 col = GetCurrentItem()->Color;
                 if (percent < 0.5) {
-                    RenderPieSlice(draw_list, center, radius, a0, a1, col);
+                    RenderPieSlice(draw_list, center, radius, a0, a1, col, hovered);
                 }
                 else {
-                    RenderPieSlice(draw_list, center, radius, a0, a0 + (a1 - a0) * 0.5, col);
-                    RenderPieSlice(draw_list, center, radius, a0 + (a1 - a0) * 0.5, a1, col);
+                    RenderPieSlice(draw_list, center, radius, a0, a0 + (a1 - a0) * 0.5, col, hovered);
+                    RenderPieSlice(draw_list, center, radius, a0 + (a1 - a0) * 0.5, a1, col, hovered);
                 }
             }
             EndItem();
@@ -2281,7 +2318,7 @@ void PlotPieChartEx(const char* const label_ids[], const T* values, int count, I
 int PieChartFormatter(double value, char* buff, int size, void* data) {
     const char* fmt = (const char*)data;
     return snprintf(buff, size, fmt, value);
-};
+}
 
 template <typename T>
 void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags) {
@@ -2320,7 +2357,9 @@ void PlotPieChart(const char* const label_ids[], const T* values, int count, dou
                     fmt((double)values[i], buffer, 32, fmt_data);
                     ImVec2 size = ImGui::CalcTextSize(buffer);
                     double angle = a0 + (a1 - a0) * 0.5;
-                    ImVec2 pos = PlotToPixels(center.x + 0.5 * radius * cos(angle), center.y + 0.5 * radius * sin(angle), IMPLOT_AUTO, IMPLOT_AUTO);
+                    const bool hovered = ImPlot::IsLegendEntryHovered(label_ids[i]) && ImHasFlag(flags, ImPlotPieChartFlags_Exploding);
+                    const double offset = (hovered ? 0.6 : 0.5) * radius;
+                    ImVec2 pos = PlotToPixels(center.x + offset * cos(angle), center.y + offset * sin(angle), IMPLOT_AUTO, IMPLOT_AUTO);
                     ImU32 col = CalcTextColor(ImGui::ColorConvertU32ToFloat4(item->Color));
                     draw_list.AddText(pos - size * 0.5f, col, buffer);
                 }
@@ -2693,15 +2732,15 @@ void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags
                 if (ImNanOrInf(itemData2.y)) itemData2.y = ImConstrainNan(ImConstrainInf(itemData2.y));
                 int pixY_0 = (int)(s.LineWeight);
                 itemData1.y = ImMax(0.0, itemData1.y);
-                float pixY_1_float = s.DigitalBitHeight * (float)itemData1.y;
-                int pixY_1 = (int)(pixY_1_float); //allow only positive values
-                int pixY_chPosOffset = (int)(ImMax(s.DigitalBitHeight, pixY_1_float) + s.DigitalBitGap);
+                const float pixY_1 = s.DigitalBitHeight * (float)itemData1.y;
+                const int pixY_chPosOffset = (int)(ImMax(s.DigitalBitHeight, pixY_1) + s.DigitalBitGap);
                 pixYMax = ImMax(pixYMax, pixY_chPosOffset);
                 ImVec2 pMin = PlotToPixels(itemData1,IMPLOT_AUTO,IMPLOT_AUTO);
                 ImVec2 pMax = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO);
-                int pixY_Offset = 0; //20 pixel from bottom due to mouse cursor label
-                pMin.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset)                   - pixY_Offset);
-                pMax.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset) - pixY_0 - pixY_1 - pixY_Offset);
+                const int pixY_Offset = 0; //20 pixel from bottom due to mouse cursor label
+                const float y_ref = y_axis.IsInverted() ? y_axis.PixelMax : y_axis.PixelMin;
+                pMin.y = y_ref - (gp.DigitalPlotOffset + pixY_Offset);
+                pMax.y = y_ref - (gp.DigitalPlotOffset + pixY_0 + (int)pixY_1 + pixY_Offset);
                 //plot only one rectangle for same digital state
                 while (((i+2) < getter.Count) && (itemData1.y == itemData2.y)) {
                     const int in = (i + 1);
@@ -2710,13 +2749,12 @@ void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags
                     pMax.x = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO).x;
                     i++;
                 }
-                //do not extend plot outside plot range
-                if (pMin.x < x_axis.PixelMin) pMin.x = x_axis.PixelMin;
-                if (pMax.x < x_axis.PixelMin) pMax.x = x_axis.PixelMin;
-                if (pMin.x > x_axis.PixelMax) pMin.x = x_axis.PixelMax - 1; //fix issue related to https://github.com/ocornut/imgui/issues/3976
-                if (pMax.x > x_axis.PixelMax) pMax.x = x_axis.PixelMax - 1; //fix issue related to https://github.com/ocornut/imgui/issues/3976
+                // do not extend plot outside plot range
+                pMin.x = ImClamp(pMin.x, !x_axis.IsInverted() ? x_axis.PixelMin : x_axis.PixelMax, !x_axis.IsInverted() ? x_axis.PixelMax - 1 : x_axis.PixelMin - 1);
+                pMax.x = ImClamp(pMax.x, !x_axis.IsInverted() ? x_axis.PixelMin : x_axis.PixelMax, !x_axis.IsInverted() ? x_axis.PixelMax - 1 : x_axis.PixelMin - 1);
+
                 //plot a rectangle that extends up to x2 with y1 height
-                if ((pMax.x > pMin.x) && (gp.CurrentPlot->PlotRect.Contains(pMin) || gp.CurrentPlot->PlotRect.Contains(pMax))) {
+                if ((gp.CurrentPlot->PlotRect.Contains(pMin) || gp.CurrentPlot->PlotRect.Contains(pMax))) {
                     // ImVec4 colAlpha = item->Color;
                     // colAlpha.w = item->Highlight ? 1.0f : 0.9f;
                     draw_list.AddRectFilled(pMin, pMax, ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]));
@@ -2750,7 +2788,11 @@ void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, in
 // [SECTION] PlotImage
 //-----------------------------------------------------------------------------
 
-void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, ImPlotImageFlags) {
+#ifdef IMGUI_HAS_TEXTURES
+void PlotImage(const char* label_id, ImTextureRef tex_ref, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, ImPlotImageFlags) {
+#else
+void PlotImage(const char* label_id, ImTextureID tex_ref, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, ImPlotImageFlags) {
+#endif
     if (BeginItemEx(label_id, FitterRect(bmin,bmax))) {
         ImU32 tint_col32 = ImGui::ColorConvertFloat4ToU32(tint_col);
         GetCurrentItem()->Color = tint_col32;
@@ -2758,7 +2800,7 @@ void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPo
         ImVec2 p1 = PlotToPixels(bmin.x, bmax.y,IMPLOT_AUTO,IMPLOT_AUTO);
         ImVec2 p2 = PlotToPixels(bmax.x, bmin.y,IMPLOT_AUTO,IMPLOT_AUTO);
         PushPlotClipRect();
-        draw_list.AddImage(user_texture_id, p1, p2, uv0, uv1, tint_col32);
+        draw_list.AddImage(tex_ref, p1, p2, uv0, uv1, tint_col32);
         PopPlotClipRect();
         EndItem();
     }
@@ -2806,3 +2848,5 @@ void PlotDummy(const char* label_id, ImPlotDummyFlags flags) {
 }
 
 } // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/core/gdxsv/gdxsv_gui_settings.cpp
+++ b/core/gdxsv/gdxsv_gui_settings.cpp
@@ -260,6 +260,17 @@ u8"分拆GPU運算去另一線程，可以降低負荷但係有可能有 1 frame
 低階 CPU 建議啓用\n\
 高階 CPU 建議停用"
 		}));
+#ifdef _WIN32
+	ImGui::Indent();
+	{
+		DisabledScope scope(!config::ThreadedRendering);
+		OptionCheckbox(t({ "Joystick Polling", u8"ジョイスティックポーリング" }), config::JoystickPolling, t({
+"Use polling instead of events for joystick input. May improve input latency in multi-threaded mode.",
+u8"ジョイスティック入力をイベントではなくポーリングで取得します。マルチスレッドモードでの入力遅延を改善する可能性があります。"
+			}));
+	}
+	ImGui::Unindent();
+#endif
 
 	bool widescreen = config::Widescreen.get() && config::WidescreenGameHacks.get();
 	pressed = ImGui::Checkbox(t({ "Enable 16:9 Widescreen Hack", u8"16:9 ワイドモニター対応", u8"使用 16:9 闊螢幕補丁" }), &widescreen);

--- a/core/gdxsv/gdxsv_gui_settings.cpp
+++ b/core/gdxsv/gdxsv_gui_settings.cpp
@@ -260,16 +260,12 @@ u8"分拆GPU運算去另一線程，可以降低負荷但係有可能有 1 frame
 低階 CPU 建議啓用\n\
 高階 CPU 建議停用"
 		}));
+
 #ifdef _WIN32
-	ImGui::Indent();
-	{
-		DisabledScope scope(!config::ThreadedRendering);
-		OptionCheckbox(t({ "Joystick Polling", u8"ジョイスティックポーリング" }), config::JoystickPolling, t({
+	OptionCheckbox(t({ "Joystick Polling", u8"ジョイスティックポーリング" }), config::JoystickPolling, t({
 "Use polling instead of events for joystick input. May improve input latency in multi-threaded mode.",
 u8"ジョイスティック入力をイベントではなくポーリングで取得します。マルチスレッドモードでの入力遅延を改善する可能性があります。"
-			}));
-	}
-	ImGui::Unindent();
+		}));
 #endif
 
 	bool widescreen = config::Widescreen.get() && config::WidescreenGameHacks.get();

--- a/core/network/ggpo.cpp
+++ b/core/network/ggpo.cpp
@@ -774,7 +774,7 @@ bool nextFrame()
 	if (useRandInput) {
 		int frame;
 		ggpo::getCurrentFrame(&frame);
-		if (frame % 5 == 0) {
+		if ((frame + localPlayerNum) % 5 == 0) {
 			kcode[0] = ~(randSource() & randInputMask);
 		}
 	}
@@ -782,8 +782,12 @@ bool nextFrame()
 	// may call save_game_state
 	int loop_count = 0;
 	do {
-		if (!config::ThreadedRendering && !useRandInput)
-			os_UpdateInputState();
+		if (!useRandInput) {
+			if (!config::ThreadedRendering)
+				os_UpdateInputState();
+			else if (config::JoystickPolling)
+				os_UpdateJoystickState();  // Polling mode: EMU thread can safely poll joystick state
+		}
 		Inputs inputs;
 		inputs.kcode = ~kcode[0];
 		if (rt[0] >= 0x4000)
@@ -883,6 +887,22 @@ bool nextFrame()
 bool active()
 {
 	return ggpoSession != nullptr;
+}
+
+bool poll()
+{
+	if (!active())
+		return false;
+
+	std::lock_guard<std::recursive_mutex> lock(ggpoMutex);
+	if (ggpoSession == nullptr)
+		return false;
+	GGPOErrorCode error = ggpo_idle(ggpoSession, 0);
+	if (error != GGPO_OK) {
+		WARN_LOG(NETWORK, "ggpo_idle in poll failed %d", error);
+		return false;
+	}
+	return true;
 }
 
 std::future<bool> startNetwork()

--- a/core/network/ggpo.h
+++ b/core/network/ggpo.h
@@ -69,6 +69,7 @@ bool isConnected(int playerNum);
 void disconnect(int playerNum);
 void randomInput(bool enable, u64 seed, u32 inputMask);
 void getNetworkStats(int playerNum, NetworkStats* stats);
+bool poll();
 std::future<bool> gdxsvStartNetwork(
     const char* sessionCode, int me,
     const std::vector<std::string>& ips,

--- a/core/oslib/oslib.cpp
+++ b/core/oslib/oslib.cpp
@@ -27,6 +27,7 @@
 #endif
 #if defined(USE_SDL)
 #include "sdl/sdl.h"
+#include "sdl/sdl_gamepad.h"
 #else
 	#if defined(SUPPORT_X11)
 		#include "linux-dist/x11.h"
@@ -485,6 +486,16 @@ void os_UpdateInputState()
 	input_sdl_handle();
 #elif defined(USE_EVDEV)
 	input_evdev_handle();
+#endif
+}
+
+void os_UpdateJoystickState()
+{
+	// Poll joystick state directly (can be called from EMU thread when polling mode is enabled)
+	// Uses SDL_HINT_JOYSTICK_THREAD on Windows to allow joystick updates from sub-threads
+	GamepadDevice::RampAnalog();
+#if defined(USE_SDL)
+	SDLGamepad::PollAllJoysticks();
 #endif
 }
 

--- a/core/oslib/oslib.h
+++ b/core/oslib/oslib.h
@@ -11,6 +11,7 @@ void os_DestroyWindow();
 void os_SetupInput();
 void os_TermInput();
 void os_UpdateInputState();
+void os_UpdateJoystickState(); // Sub-thread safe joystick state update (uses SDL_HINT_JOYSTICK_THREAD)
 void os_InstallFaultHandler();
 void os_UninstallFaultHandler();
 void os_RunInstance(int argc, const char *argv[]);

--- a/core/profiler/fc_profiler.h
+++ b/core/profiler/fc_profiler.h
@@ -5,6 +5,7 @@
 #include "types.h"
 #include <vector>
 #include <string>
+#include <cstring>
 #include <chrono>
 #include <thread>
 #include <mutex>

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -30,6 +30,7 @@
 #include "switch_gamepad.h"
 #endif
 #include "dreamlink.h"
+#include "cfg/option.h"
 #include <unordered_map>
 
 static SDL_Window* window = NULL;
@@ -212,6 +213,8 @@ void input_sdl_init()
 		}
 		// Don't close the app when pressing the B button
 		SDL_SetHint(SDL_HINT_WINRT_HANDLE_BACK_BUTTON, "1");
+		// Use separate thread for joystick input handling
+		SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
 #endif
 		std::string db = get_readonly_data_path("gamecontrollerdb.txt");
 		int rv = SDL_GameControllerAddMappingsFromFile(db.c_str());
@@ -305,6 +308,7 @@ static std::shared_ptr<SDLMouse> getMouse(u64 mouseId)
 	}
 	return mouse;
 }
+
 
 void input_sdl_handle()
 {
@@ -420,6 +424,7 @@ void input_sdl_handle()
 
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
+				if (!config::JoystickPolling)
 				{
 					std::shared_ptr<SDLGamepad> device = SDLGamepad::GetSDLGamepad((SDL_JoystickID)event.jbutton.which);
 					if (device != NULL)
@@ -427,6 +432,7 @@ void input_sdl_handle()
 				}
 				break;
 			case SDL_JOYAXISMOTION:
+				if (!config::JoystickPolling)
 				{
 					std::shared_ptr<SDLGamepad> device = SDLGamepad::GetSDLGamepad((SDL_JoystickID)event.jaxis.which);
 					if (device != NULL)
@@ -434,6 +440,7 @@ void input_sdl_handle()
 				}
 				break;
 			case SDL_JOYHATMOTION:
+				if (!config::JoystickPolling)
 				{
 					std::shared_ptr<SDLGamepad> device = SDLGamepad::GetSDLGamepad((SDL_JoystickID)event.jhat.which);
 					if (device != NULL)
@@ -589,6 +596,10 @@ void input_sdl_handle()
 				break;
 		}
 	}
+
+	// When polling mode is enabled, poll joystick state here (main thread)
+	if (config::JoystickPolling)
+		SDLGamepad::PollAllJoysticks();
 }
 
 static float hdpiScaling = 1.f;

--- a/core/sdl/sdl_gamepad.cpp
+++ b/core/sdl/sdl_gamepad.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 
 std::map<SDL_JoystickID, std::shared_ptr<SDLGamepad>> SDLGamepad::sdl_gamepads;
+std::mutex SDLGamepad::pollMutex;
 
 template<bool Arcade = false, bool Gamepad = false>
 class DefaultInputMapping : public InputMapping
@@ -698,4 +699,98 @@ SDLMouse::SDLMouse(u64 mouseId) : Mouse("SDL")
 		this->_unique_id = "sdl_mouse_" + std::to_string(mouseId);
 	}
 	loadMapping();
+}
+
+void SDLGamepad::pollState()
+{
+	if (sdl_joystick == nullptr)
+		return;
+
+	int numButtons = std::min(SDL_JoystickNumButtons(sdl_joystick), 64);
+	int numAxes = SDL_JoystickNumAxes(sdl_joystick);
+	int numHats = std::min(SDL_JoystickNumHats(sdl_joystick), 8);
+
+	// Initialize axis state vector on first poll
+	if (prevAxisState.size() != (size_t)numAxes)
+		prevAxisState.resize(numAxes, 0);
+
+	// Poll buttons (bitmask)
+	u64 buttons = 0;
+	for (int i = 0; i < numButtons; i++)
+	{
+		if (SDL_JoystickGetButton(sdl_joystick, i))
+			buttons |= (1ULL << i);
+	}
+	u64 changed = buttons ^ prevButtons;
+	if (changed)
+	{
+		for (int i = 0; i < numButtons; i++)
+		{
+			if (changed & (1ULL << i))
+				gamepad_btn_input(i, (buttons & (1ULL << i)) != 0);
+		}
+		prevButtons = buttons;
+	}
+
+	// Poll axes
+	for (int i = 0; i < numAxes; i++)
+	{
+		Sint16 value = SDL_JoystickGetAxis(sdl_joystick, i);
+		if (value != prevAxisState[i])
+		{
+			prevAxisState[i] = value;
+			gamepad_axis_input(i, value);
+		}
+	}
+
+	// Poll hats (4 bits per hat)
+	u32 hats = 0;
+	for (int i = 0; i < numHats; i++)
+		hats |= (SDL_JoystickGetHat(sdl_joystick, i) & 0xF) << (i * 4);
+
+	u32 hatChanged = hats ^ prevHats;
+	if (hatChanged)
+	{
+		for (int i = 0; i < numHats; i++)
+		{
+			if (hatChanged & (0xF << (i * 4)))
+			{
+				Uint8 hatValue = (hats >> (i * 4)) & 0xF;
+				u32 hatid = (i + 1) << 8;
+				// Up/Down
+				if (hatValue & SDL_HAT_UP)
+				{
+					gamepad_btn_input(hatid + 0, true);
+					gamepad_btn_input(hatid + 1, false);
+				}
+				else if (hatValue & SDL_HAT_DOWN)
+				{
+					gamepad_btn_input(hatid + 0, false);
+					gamepad_btn_input(hatid + 1, true);
+				}
+				else
+				{
+					gamepad_btn_input(hatid + 0, false);
+					gamepad_btn_input(hatid + 1, false);
+				}
+				// Left/Right
+				if (hatValue & SDL_HAT_LEFT)
+				{
+					gamepad_btn_input(hatid + 2, true);
+					gamepad_btn_input(hatid + 3, false);
+				}
+				else if (hatValue & SDL_HAT_RIGHT)
+				{
+					gamepad_btn_input(hatid + 2, false);
+					gamepad_btn_input(hatid + 3, true);
+				}
+				else
+				{
+					gamepad_btn_input(hatid + 2, false);
+					gamepad_btn_input(hatid + 3, false);
+				}
+			}
+		}
+		prevHats = hats;
+	}
 }

--- a/core/sdl/sdl_gamepad.h
+++ b/core/sdl/sdl_gamepad.h
@@ -18,6 +18,7 @@
 #include "input/gamepad_device.h"
 #include "input/mouse.h"
 #include "sdl.h"
+#include <mutex>
 
 class SDLGamepad : public GamepadDevice
 {
@@ -65,6 +66,16 @@ public:
 		for (auto &[k, gamepad] : sdl_gamepads)
 			gamepad->update_rumble();
 	}
+	static void PollAllJoysticks() {
+		// Poll joystick state directly without using events
+		// Can be called from sub-thread when SDL_HINT_JOYSTICK_THREAD is enabled
+		// Mutex protects against concurrent calls from main thread and EMU thread
+		std::lock_guard<std::mutex> lock(pollMutex);
+		SDL_JoystickUpdate();
+		for (auto &[k, gamepad] : sdl_gamepads)
+			gamepad->pollState();
+	}
+	void pollState();
 
 	static void SetTorque(int port, float torque) {
 		applyToPort(port, &SDLGamepad::setTorque, torque);
@@ -101,6 +112,7 @@ private:
 	float vib_inclination = 0;
 	SDL_GameController *sdl_controller = nullptr;
 	static std::map<SDL_JoystickID, std::shared_ptr<SDLGamepad>> sdl_gamepads;
+	static std::mutex pollMutex;
 	SDL_Haptic *haptic = nullptr;
 	bool hapticRumble = false;
 	bool hasAutocenter = false;
@@ -109,6 +121,10 @@ private:
 	int constEffectId = -1;
 	int springEffectId = -1;
 	int damperEffectId = -1;
+	// State tracking for polling mode
+	u64 prevButtons = 0;       // Bitmask for up to 64 buttons
+	u32 prevHats = 0;          // 4 bits per hat, up to 8 hats
+	std::vector<Sint16> prevAxisState;
 };
 
 class SDLMouse : public Mouse

--- a/core/ui/mainui.cpp
+++ b/core/ui/mainui.cpp
@@ -114,10 +114,34 @@ void mainui_loop(bool forceStart)
 			return;
 
 		const auto period = get_period();
-		const auto deltaUs = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
+		const int64_t minSleepMargin = 2000; // 2ms margin for sleep_and_busy_wait
+		const int64_t pollInterval = 1000;   // 1ms between polls
 		int64_t overSlept = 0;
-		if (deltaUs < period)
-			overSlept = sleep_and_busy_wait(period - deltaUs);
+
+		auto getElapsed = [&start]() {
+			return std::chrono::duration_cast<std::chrono::microseconds>(
+				std::chrono::steady_clock::now() - start).count();
+		};
+
+		if (ggpo::active() && !config::ThreadedRendering) {
+			// Poll GGPO while waiting, leaving margin for precise sleep
+			// Only in single-threaded mode to avoid conflicts with emu thread
+			while (true) {
+				auto remaining = period - getElapsed();
+				if (remaining <= minSleepMargin)
+					break;
+				if (!ggpo::poll())
+					break;
+				remaining = period - getElapsed();
+				if (remaining > minSleepMargin + pollInterval)
+					sleep_us(pollInterval);
+			}
+		}
+
+		auto remaining = period - getElapsed();
+		if (remaining > 0)
+			overSlept = sleep_and_busy_wait(remaining);
+
 		start = std::chrono::steady_clock::now();
 		if (1000 <= overSlept)
 			WARN_LOG(RENDERER, "FixedFrequency: Over slept %d [us]", overSlept);

--- a/core/ui/mainui.cpp
+++ b/core/ui/mainui.cpp
@@ -132,21 +132,12 @@ void mainui_loop(bool forceStart)
 	while (mainui_enabled)
 	{
 		fc_profiler::startThread("main");
-
-		if (mainui_rend_frame())
-			fixedFrequencyWait();
+		const auto rendered = mainui_rend_frame();
 
 		if (imguiDriver == nullptr)
 			forceReinit = true;
 		else
 			imguiDriver->present();
-
-		if (ggpo::active() && 0 < ggpo::timeSyncFrames) {
-			if (MainFrameCount % timeSyncInterval(ggpo::timeSyncFrames) == 0) {
-				ggpo::timeSyncFrames.fetch_sub(1);
-				fixedFrequencyWait();
-			}
-		}
 
 		if (currentDupeFrames != config::DupeFrames) {
 			forceReinit = true;
@@ -166,6 +157,16 @@ void mainui_loop(bool forceStart)
 		}
 
 		gdxsv_emu_mainui_loop();
+
+		if (rendered)
+			fixedFrequencyWait();
+
+		if (ggpo::active() && 0 < ggpo::timeSyncFrames) {
+			if (MainFrameCount % timeSyncInterval(ggpo::timeSyncFrames) == 0) {
+				ggpo::timeSyncFrames.fetch_sub(1);
+				fixedFrequencyWait();
+			}
+		}
 
 		fc_profiler::endThread(config::ProfilerFrameWarningTime);
 	}

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -1027,6 +1027,9 @@ void gui_settings_controls(bool& maple_devices_changed)
 	OptionSlider("Mouse sensitivity", config::MouseSensitivity, 1, 500);
 #if defined(_WIN32) && !defined(TARGET_UWP)
 	OptionCheckbox("Use Raw Input", config::UseRawInput, "Supports multiple pointing devices (mice, light guns) and keyboards");
+	OptionCheckbox("Joystick Polling", config::JoystickPolling,
+		"Use polling instead of events for joystick input. "
+		"May improve input latency for GGPO in multi-threaded mode.");
 #endif
 #ifdef USE_DREAMLINK_DEVICES
 	{


### PR DESCRIPTION
- The frame time was unstable because the fixedFrequency sleep was executed too early.
- Periodically call ggpo_idle within fixedFrequency (single-thread only).
- Use SDL_HINT_JOYSTICK_THREAD to receive the latest input (Windows and Xinput only).
- Updating ImPlot