### PR TITLE
Revert "Avoid texture glitch"

### DIFF
--- a/core/rend/TexCache.cpp
+++ b/core/rend/TexCache.cpp
@@ -512,8 +512,6 @@ bool BaseTextureCacheData::Update()
 	{
 		u32 oldHash = texture_hash;
 		ComputeHash();
-		// gdxsv: Avoid texture glitch issue https://github.com/flyinghead/flycast/issues/2189
-		/*
 		if (Updates > 1 && oldHash == texture_hash)
 		{
 			// Texture hasn't changed so skip the update.
@@ -526,7 +524,6 @@ bool BaseTextureCacheData::Update()
 			size = originalSize;
 			return true;
 		}
-		*/
 		custom_texture.loadCustomTextureAsync(this);
 	}
 	is_custom_replaced = false;


### PR DESCRIPTION
This reverts commit 77e5f96e65ee6d9b04770276a6bc01a3da21e501.

The texture glitch has been fixed by https://github.com/inada-s/flycast/pull/301/commits/991d90d089ba105a529a948515e6c523913b3a96
