### PR TITLE
Add option to disable DirectInput for 8bitdo controllers

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -110,9 +110,6 @@ Option<int> AnisotropicFiltering("rend.AnisotropicFiltering", 1);
 Option<int> TextureFiltering("rend.TextureFiltering", 0); // Default
 Option<bool> ThreadedRendering("rend.ThreadedRendering", true);
 Option<bool> DupeFrames("rend.DupeFrames", false);
-#ifdef _WIN32
-Option<bool> JoystickPolling("input.JoystickPolling", false);
-#endif
 Option<int> PerPixelLayers("rend.PerPixelLayers", 32);
 #ifdef TARGET_UWP
 Option<bool> NativeDepthInterpolation("rend.NativeDepthInterpolation", true);
@@ -247,6 +244,9 @@ std::array<Option<bool>, 4> UseNetworkExpansionDevices{
 Option<bool> PerGameVmu("PerGameVmu", false, "config");
 #ifdef _WIN32
 Option<bool, false> UseRawInput("RawInput", false, "input");
+Option<bool, false> UseXInput("UseXInput", true, "input");
+Option<bool, false> UseDirectInput("UseDirectInput", true, "input");
+Option<bool, false> JoystickPolling("JoystickPolling", false, "input");
 #endif
 Option<bool> UsePhysicalVmuMemory("UsePhysicalVmuMemory", true);
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -470,11 +470,6 @@ extern Option<int> AnisotropicFiltering;
 extern Option<int> TextureFiltering; // 0: default, 1: force nearest, 2: force linear
 extern Option<bool> ThreadedRendering;
 extern Option<bool> DupeFrames;
-#ifdef _WIN32
-extern Option<bool> JoystickPolling;
-#else
-constexpr bool JoystickPolling = false;
-#endif
 extern Option<bool> NativeDepthInterpolation;
 extern Option<bool> EmulateFramebuffer;
 extern Option<int> FixedFrequency;
@@ -578,7 +573,11 @@ extern std::array<Option<bool>, 4> UseNetworkExpansionDevices;
 extern Option<bool> PerGameVmu;
 #ifdef _WIN32
 extern Option<bool, false> UseRawInput;
+extern Option<bool, false> UseXInput;
+extern Option<bool, false> UseDirectInput;
+extern Option<bool, false> JoystickPolling;
 #else
+constexpr bool JoystickPolling = false;
 constexpr bool UseRawInput = false;
 #endif
 extern Option<bool> UsePhysicalVmuMemory;

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -205,11 +205,17 @@ void input_sdl_init()
 		// We want joystick events even if we loose focus
 		SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 #ifdef _WIN32
-		if (cfgLoadBool("input", "DisableXInput", false))
+		if (!config::UseXInput)
 		{
 			// Disable XInput for some old joysticks
 			NOTICE_LOG(INPUT, "Disabling XInput, using DirectInput");
 			SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "0");
+		}
+		if (!config::UseDirectInput)
+		{
+			// Disable DirectInput
+			NOTICE_LOG(INPUT, "Disabling DirectInput");
+			SDL_SetHint(SDL_HINT_DIRECTINPUT_ENABLED, "0");
 		}
 		// Don't close the app when pressing the B button
 		SDL_SetHint(SDL_HINT_WINRT_HANDLE_BACK_BUTTON, "1");

--- a/core/ui/settings_controls.cpp
+++ b/core/ui/settings_controls.cpp
@@ -1027,6 +1027,10 @@ void gui_settings_controls(bool& maple_devices_changed)
 	OptionSlider("Mouse sensitivity", config::MouseSensitivity, 1, 500);
 #if defined(_WIN32) && !defined(TARGET_UWP)
 	OptionCheckbox("Use Raw Input", config::UseRawInput, "Supports multiple pointing devices (mice, light guns) and keyboards");
+	ImGui::SameLine(0, uiScaled(16));
+	OptionCheckbox("Use XInput", config::UseXInput, "Enable XInput devices");
+	ImGui::SameLine(0, uiScaled(16));
+	OptionCheckbox("Use DirectInput", config::UseDirectInput, "Enable XInput devices");
 	OptionCheckbox("Joystick Polling", config::JoystickPolling,
 		"Use polling instead of events for joystick input. "
 		"May improve input latency for GGPO in multi-threaded mode.");


### PR DESCRIPTION
- With 8Bitdo M30Bluetooth, SDL hangs when trying to get DirectInput information, so disable it.