### PR TITLE
Set HIGH_PRIORITY_CLASS on windows

### DIFF
--- a/core/sleep.cpp
+++ b/core/sleep.cpp
@@ -23,6 +23,7 @@ static NTSTATUS(__stdcall* ZwSetTimerResolution)(IN ULONG RequestedResolution, I
 void set_timer_resolution()
 {
 #if _WIN32
+	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
 	ULONG actual_resolution;
 	ZwSetTimerResolution(1, true, &actual_resolution);
 #elif __APPLE__


### PR DESCRIPTION
- Set HIGH_PRIORITY_CLASS at startup. It increases the accuracy of fixedFrequency.