### PR TITLE
Fix an issue where the new user will be stuck in new account creation loop

### DIFF
--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -118,6 +118,7 @@ void Gdxsv::Reset() {
 
 	if (config::GdxLoginKey.get().empty()) {
 		config::GdxLoginKey = GenerateLoginKey();
+		config::GdxLoginKey.save();
 	}
 
 	NOTICE_LOG(COMMON, "gdxsv disk:%d server:%s loginkey:%s udp_port:%d", (int)disk_, config::GdxLobbyServer.get().c_str(),


### PR DESCRIPTION
The `config::GdxLoginKey` was generated but not persisted to the configuration file, causing it to be lost on restart and forcing a new account creation.