### PR TITLE
gdxsv: improve ping test reliability by taking the best of 3 attempts

### DIFF
--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -125,39 +125,39 @@ std::future<std::map<std::string, int>> gcp_ping_test() {
 
 		// Function to test a single region
 		auto test_region = [&get_path](const std::tuple<std::string, std::string, std::string> &region_host) -> std::pair<std::string, int> {
+			TcpClient client;
+			if (!client.Connect(std::get<1>(region_host).c_str(), 80)) {
+				ERROR_LOG(COMMON, "connect failed : %s", std::get<0>(region_host).c_str());
+				return {"", -1};
+			}
+
 			int min_rtt = -1;
 			for (int i = 0; i < 3; i++) {
-				TcpClient client;
 				std::stringstream ss;
 				ss << "HEAD " << get_path << " HTTP/1.1"
 				   << "\r\n";
 				ss << "Host: " << std::get<1>(region_host) << "\r\n";
 				ss << "User-Agent: flycast for gdxsv"
 				   << "\r\n";
+				ss << "Connection: keep-alive"
+				   << "\r\n";
 				ss << "Accept: */*"
 				   << "\r\n";
 				ss << "\r\n";  // end of header
 
-				if (!client.Connect(std::get<1>(region_host).c_str(), 80)) {
-					ERROR_LOG(COMMON, "connect failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
-					continue;
-				}
-
 				auto request_header = ss.str();
 				auto t1 = std::chrono::high_resolution_clock::now();
-				int n = client.Send(request_header.c_str(), request_header.size());
+				int n = client.Send(request_header.c_str(), (int)request_header.size());
 				if (n < request_header.size()) {
 					ERROR_LOG(COMMON, "send failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
-					client.Close();
-					continue;
+					break;
 				}
 
 				char buf[1024] = {0};
 				n = client.Recv(buf, 1024);
 				if (n <= 0) {
 					ERROR_LOG(COMMON, "recv failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
-					client.Close();
-					continue;
+					break;
 				}
 
 				auto t2 = std::chrono::high_resolution_clock::now();
@@ -165,11 +165,8 @@ std::future<std::map<std::string, int>> gcp_ping_test() {
 				const std::string response_header(buf, n);
 				if (response_header.find("200 OK") == std::string::npos && response_header.find("302 Found") == std::string::npos) {
 					ERROR_LOG(COMMON, "error response : %s (attempt %d)", response_header.c_str(), i + 1);
-					client.Close();
-					continue;
+					break;
 				}
-
-				client.Close();
 
 				NOTICE_LOG(COMMON, "%s : attempt %d: %d[ms]", std::get<2>(region_host).c_str(), i + 1, rtt);
 
@@ -177,6 +174,8 @@ std::future<std::map<std::string, int>> gcp_ping_test() {
 					min_rtt = rtt;
 				}
 			}
+
+			client.Close();
 
 			if (min_rtt == -1) {
 				ERROR_LOG(COMMON, "Ping test failed for all attempts : %s", std::get<0>(region_host).c_str());

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -125,56 +125,70 @@ std::future<std::map<std::string, int>> gcp_ping_test() {
 
 		// Function to test a single region
 		auto test_region = [&get_path](const std::tuple<std::string, std::string, std::string> &region_host) -> std::pair<std::string, int> {
-			TcpClient client;
-			std::stringstream ss;
-			ss << "HEAD " << get_path << " HTTP/1.1"
-			   << "\r\n";
-			ss << "Host: " << std::get<1>(region_host)<< "\r\n";
-			ss << "User-Agent: flycast for gdxsv"
-			   << "\r\n";
-			ss << "Accept: */*"
-			   << "\r\n";
-			ss << "\r\n";  // end of header
+			int min_rtt = -1;
+			for (int i = 0; i < 3; i++) {
+				TcpClient client;
+				std::stringstream ss;
+				ss << "HEAD " << get_path << " HTTP/1.1"
+				   << "\r\n";
+				ss << "Host: " << std::get<1>(region_host) << "\r\n";
+				ss << "User-Agent: flycast for gdxsv"
+				   << "\r\n";
+				ss << "Accept: */*"
+				   << "\r\n";
+				ss << "\r\n";  // end of header
 
-			if (!client.Connect(std::get<1>(region_host).c_str(), 80)) {
-				ERROR_LOG(COMMON, "connect failed : %s", std::get<0>(region_host).c_str());
-				return {"", -1};
-			}
+				if (!client.Connect(std::get<1>(region_host).c_str(), 80)) {
+					ERROR_LOG(COMMON, "connect failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
+					continue;
+				}
 
-			auto request_header = ss.str();
-			auto t1 = std::chrono::high_resolution_clock::now();
-			int n = client.Send(request_header.c_str(), request_header.size());
-			if (n < request_header.size()) {
-				ERROR_LOG(COMMON, "send failed : %s", std::get<0>(region_host).c_str());
+				auto request_header = ss.str();
+				auto t1 = std::chrono::high_resolution_clock::now();
+				int n = client.Send(request_header.c_str(), request_header.size());
+				if (n < request_header.size()) {
+					ERROR_LOG(COMMON, "send failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
+					client.Close();
+					continue;
+				}
+
+				char buf[1024] = {0};
+				n = client.Recv(buf, 1024);
+				if (n <= 0) {
+					ERROR_LOG(COMMON, "recv failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
+					client.Close();
+					continue;
+				}
+
+				auto t2 = std::chrono::high_resolution_clock::now();
+				int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+				const std::string response_header(buf, n);
+				if (response_header.find("200 OK") == std::string::npos && response_header.find("302 Found") == std::string::npos) {
+					ERROR_LOG(COMMON, "error response : %s (attempt %d)", response_header.c_str(), i + 1);
+					client.Close();
+					continue;
+				}
+
 				client.Close();
-				return {"", -1};
+
+				NOTICE_LOG(COMMON, "%s : attempt %d: %d[ms]", std::get<2>(region_host).c_str(), i + 1, rtt);
+
+				if (min_rtt == -1 || rtt < min_rtt) {
+					min_rtt = rtt;
+				}
 			}
 
-			char buf[1024] = {0};
-			n = client.Recv(buf, 1024);
-			if (n <= 0) {
-				ERROR_LOG(COMMON, "recv failed : %s", std::get<0>(region_host).c_str());
-				client.Close();
+			if (min_rtt == -1) {
+				ERROR_LOG(COMMON, "Ping test failed for all attempts : %s", std::get<0>(region_host).c_str());
 				return {"", -1};
 			}
-
-			auto t2 = std::chrono::high_resolution_clock::now();
-			int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-			const std::string response_header(buf, n);
-			if (response_header.find("200 OK") == std::string::npos && response_header.find("302 Found") == std::string::npos) {
-				ERROR_LOG(COMMON, "error response : %s", response_header.c_str());
-				client.Close();
-				return {"", -1};
-			}
-
-			client.Close();
 
 			char latency_str[256];
-			snprintf(latency_str, 256, "%s : %d[ms]", std::get<2>(region_host).c_str(), rtt);
+			snprintf(latency_str, 256, "%s : %d[ms]", std::get<2>(region_host).c_str(), min_rtt);
 			NOTICE_LOG(COMMON, "%s", latency_str);
 			gdxsv.SetPingResult(std::string(latency_str));
 
-			return {std::get<0>(region_host), rtt};
+			return {std::get<0>(region_host), min_rtt};
 		};
 
 		// Execute ping tests with max 6 parallel workers


### PR DESCRIPTION
Problem: A user from Hong Kong cannot enter Hong Kong lobby
![telegram-cloud-photo-size-5-6298458845848126182-y](https://github.com/user-attachments/assets/a2ec93b2-be5b-4782-b9ef-6e35b76c1653)


Some users experience high latency on their first connection attempt, causing them to be incorrectly blocked from region-specific lobbies.

Usually they would need to relaunch Flycast, and then force latency check again, then they can enter the Hong Kong lobby.

Since we are pinging concurrently now, we can:
 - Pings each GCP region 3 times instead of once.
 - Uses the minimum RTT value for the lobby eligibility check.

icmp example from my wired connection:
<img width="485" height="90" alt="Screenshot 2026-02-04 at 6 52 48 PM" src="https://github.com/user-attachments/assets/ecdb5971-2fbb-45a4-af21-e7e15a5995ee" />

<img width="792" height="244" alt="Screenshot 2026-02-04 at 6 52 33 PM" src="https://github.com/user-attachments/assets/6a2ab20f-8e39-41d5-9fa6-79a5dd1e07c1" />
