### PR TITLE
macOS: Fix connection medium check stuck with bad DNS settings

### DIFF
--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -243,7 +243,7 @@ NSString* runCommand(NSString* commandToRun) {
 }
 
 std::string os_GetConnectionMedium() {
-    NSString* bestInterface = runCommand(@"route get 8.8.8.8 | grep interface | awk '{split($0,a,\": \"); printf \"%s\", a[2]}'");
+    NSString* bestInterface = runCommand(@"route -n get 8.8.8.8 | grep interface | awk '{split($0,a,\": \"); printf \"%s\", a[2]}'");
 
 	if ( bestInterface == nil || [bestInterface isEqual:[NSNull null]] || ([bestInterface respondsToSelector:@selector(length)] && [bestInterface length] == 0)) {
 		return "Unknown";


### PR DESCRIPTION
The `route get` would resolve the IP to hostname and try to pretty print (reverse DNS)
But some user reported that when they are using ISP provided DNS, this resolve is super slow.

Changing to `route -n`
```
-n      Bypass attempts to print host and network names symbolically when reporting actions.
```
so that the connection medium check can be done immediately