### PR TITLE
Native network interface detection and Windows VPN detection

### DIFF
--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -25,7 +25,8 @@ using namespace nlohmann;
 
 static void gdxsv_update_popup();
 static void gdxsv_texture_update_popup();
-static void wireless_warning_popup();
+static void wireless_warning_popup(const std::string& connection_medium);
+static void vpn_warning_toast(const std::string& connection_medium);
 
 bool gdxsv_enabled() { return gdxsv.Enabled(); }
 
@@ -132,7 +133,10 @@ void gdxsv_emu_gui_display() {
 	if (gui_state == GuiState::Main) {
 		gdxsv_update_popup();
 		gdxsv_texture_update_popup();
-		wireless_warning_popup();
+		
+		static std::string connection_medium = os_GetConnectionMedium();
+		wireless_warning_popup(connection_medium);
+		vpn_warning_toast(connection_medium);
 	}
 
 	if (gui_state == GuiState::GdxsvReplay) {
@@ -361,14 +365,13 @@ static void gdxsv_texture_update_popup() {
 	ImGui::PopStyleVar(2);
 }
 
-static void wireless_warning_popup() {
-	static bool show_wireless_warning = true;
-	static std::string connection_medium = os_GetConnectionMedium();
+static void wireless_warning_popup(const std::string& connection_medium) {
+	static bool initialized = false;
 	const bool no_popup_opened = !ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopupId);
 
-	if (show_wireless_warning && no_popup_opened && connection_medium == "Wireless") {
+	if (!initialized && no_popup_opened && connection_medium == "Wireless") {
 		ImGui::OpenPopup("Wireless connection detected");
-		show_wireless_warning = false;
+		initialized = true;
 	}
 
 	if (ImGui::BeginPopupModal("Wireless connection detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
@@ -385,34 +388,80 @@ static void wireless_warning_popup() {
 		ImGui::PopStyleVar();
 		ImGui::EndPopup();
 	}
+}
+
+static void vpn_warning_toast(const std::string& connection_medium) {
+	struct Toast
+	{
+		bool active = false;
+		bool shown = false;
+		float timer = 6.0f;
+	};
+	static Toast vpnToast;
 	
-	if (show_wireless_warning && no_popup_opened && connection_medium == "VPN") {
-		ImGui::OpenPopup("Possible VPN / virtual network detected");
-		show_wireless_warning = false;
+	static bool initialized = false;
+	if (!initialized) {
+		vpnToast.active = connection_medium.find("VPN") == 0;
+		initialized = true;
 	}
 	
-	ImGui::SetNextWindowSizeConstraints(ScaledVec2(400.f, 0.f), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::BeginPopupModal("Possible VPN / virtual network detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		
-		ImGui::SetCursorPosX(ImGui::GetCursorPos().x + uiScaled(6.f));
-		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f - 12.f));
-		ImGui::TextWrapped(
-						   "Your connection appears to use a VPN or virtual network interface.\n"
-						   "This may cause latency or instability.\n"
-						   "Please disable VPNs or use a direct network connection."
-						   );
-		ImGui::PopTextWrapPos();
-		
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
-		float currentwidth = ImGui::GetContentRegionAvail().x;
-		
-		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x);
-		if (ImGui::Button("OK", ScaledVec2(100.f, 0.f))) {
-			ImGui::CloseCurrentPopup();
+	static float anim = 0.f;
+	float dt = ImGui::GetIO().DeltaTime;
+
+	if (vpnToast.active && !vpnToast.shown)
+	{
+		if (vpnToast.timer > 0.f)
+		{
+			vpnToast.timer -= dt;
+			anim = ImMin(anim + dt * 3.0f, 1.0f);
 		}
-		ImGui::SetItemDefaultFocus();
+		else
+		{
+			anim = ImMax(anim - dt * 3.0f, 0.0f);
+			if (anim <= 0.f)
+				vpnToast.shown = true;
+		}
+	}
+
+	if (anim > 0.f)
+	{
+		ImGui::SetNextWindowBgAlpha(0.8f * anim);
+		float margin = uiScaled(24.0f);
+		
+		float slide = (vpnToast.timer > 0.f) ? ImLerp(-(uiScaled(460.0f) + margin), 0.0f, anim) : 0.0f;
+		ImGuiViewport* vp = ImGui::GetMainViewport();
+
+		ImVec2 pos;
+		pos.x = vp->WorkPos.x + margin + slide;
+		pos.y = vp->WorkPos.y + vp->WorkSize.y - margin;
+
+		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, anim);
+		ImGui::SetNextWindowPos(pos, ImGuiCond_Always, ImVec2(0.0f, 1.0f));
+		ImGui::SetNextWindowSizeConstraints(ScaledVec2(460.f, 0.f), ImVec2(FLT_MAX, FLT_MAX));
+
+		ImGuiWindowFlags flags =
+			ImGuiWindowFlags_NoDecoration |
+			ImGuiWindowFlags_NoMove |
+			ImGuiWindowFlags_AlwaysAutoResize |
+			ImGuiWindowFlags_NoFocusOnAppearing |
+			ImGuiWindowFlags_NoNav |
+			ImGuiWindowFlags_Tooltip;
+
+		if (ImGui::Begin("##VPNToast", nullptr, flags))
+		{
+			std::string vpn_name = "";
+			if (connection_medium.find("VPN: ") == 0)
+				vpn_name = " - " + connection_medium.substr(5);
+			
+			ImGui::Text("Possible VPN / virtual network detected %s", vpn_name.c_str());
+			ImGui::Separator();
+			ImGui::TextWrapped(
+				"Your connection appears to use a VPN or virtual network interface.\n"
+				"If matches feel unstable, try a direct connection."
+			);
+		}
+		ImGui::End();
 		ImGui::PopStyleVar();
-		ImGui::EndPopup();
 	}
 }
 

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -247,6 +247,7 @@ static void gdxsv_update_popup() {
 	if (ImGui::BeginPopupModal("New version", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
 		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
 		ImGui::TextWrapped("  %s is available for download!  ", gdxsv_update.GetLatestVersionTag().c_str());
+		ImGui::PopTextWrapPos();
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
 		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
@@ -377,6 +378,7 @@ static void wireless_warning_popup(const std::string& connection_medium) {
 	if (ImGui::BeginPopupModal("Wireless connection detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
 		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
 		ImGui::TextWrapped("  Please use LAN cable for the best gameplay experience!  ");
+		ImGui::PopTextWrapPos();
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
 

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -241,29 +241,27 @@ static void gdxsv_update_popup() {
 	}
 
 	if (ImGui::BeginPopupModal("New version", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 400.f * settings.display.uiScale);
+		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
 		ImGui::TextWrapped("  %s is available for download!  ", gdxsv_update.GetLatestVersionTag().c_str());
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * settings.display.uiScale, 3 * settings.display.uiScale));
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
-		ImGui::SetCursorPosX((currentwidth - 100.f * settings.display.uiScale) / 2.f + ImGui::GetStyle().WindowPadding.x -
-							 -55.f * settings.display.uiScale);
+		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
 		if (GdxsvUpdate::IsSupportSelfUpdate()) {
-			if (ImGui::Button("Update", ImVec2(100.f * settings.display.uiScale, 0.f))) {
+			if (ImGui::Button("Update", ScaledVec2(100.f, 0.f))) {
 				self_update_result = gdxsv_update.StartSelfUpdate();
 				update_popup_shown = true;
 				ImGui::CloseCurrentPopup();
 			}
 		} else {
-			if (ImGui::Button("Download", ImVec2(100.f * settings.display.uiScale, 0.f))) {
+			if (ImGui::Button("Download", ScaledVec2(100.f, 0.f))) {
 				os_LaunchFromURL(GdxsvUpdate::DownloadPageURL());
 				update_popup_shown = true;
 				ImGui::CloseCurrentPopup();
 			}
 		}
 		ImGui::SameLine();
-		ImGui::SetCursorPosX((currentwidth - 100.f * settings.display.uiScale) / 2.f + ImGui::GetStyle().WindowPadding.x +
-							 -55.f * settings.display.uiScale);
-		if (ImGui::Button("Cancel", ImVec2(100.f * settings.display.uiScale, 0.f))) {
+		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
+		if (ImGui::Button("Cancel", ScaledVec2(100.f, 0.f))) {
 			update_popup_shown = true;
 			ImGui::CloseCurrentPopup();
 		}
@@ -282,7 +280,7 @@ static void gdxsv_update_popup() {
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, padding);
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, padding);
 	if (ImGui::BeginPopupModal("Update", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * settings.display.uiScale, 3 * settings.display.uiScale));
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 
 		if (self_update_result.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
 			if (self_update_result.get()) {
@@ -307,10 +305,9 @@ static void gdxsv_update_popup() {
 		} else {
 			ImGui::Text("Updating...");
 			ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(0.557f, 0.268f, 0.965f, 1.f));
-			ImGui::ProgressBar(gdxsv_update.SelfUpdateProgress(), ImVec2(-1, 20.f * settings.display.uiScale));
+			ImGui::ProgressBar(gdxsv_update.SelfUpdateProgress(), ScaledVec2(-1, 20.f));
 			ImGui::PopStyleColor();
 		}
-
 		ImGui::SetItemDefaultFocus();
 		ImGui::PopStyleVar();
 		ImGui::EndPopup();
@@ -338,7 +335,7 @@ static void gdxsv_texture_update_popup() {
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, padding);
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, padding);
 	if (ImGui::BeginPopupModal("Updating texture", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * settings.display.uiScale, 3 * settings.display.uiScale));
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 
 		if (self_update_result.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
 			if (self_update_result.get()) {
@@ -353,7 +350,7 @@ static void gdxsv_texture_update_popup() {
 		} else {
 			ImGui::Text("Updating...");
 			ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(0.557f, 0.268f, 0.965f, 1.f));
-			ImGui::ProgressBar(gdxsv_custom_texture_update.UpdateProgress(), ImVec2(-1, 20.f * settings.display.uiScale));
+			ImGui::ProgressBar(gdxsv_custom_texture_update.UpdateProgress(), ScaledVec2(-1, 20.f));
 			ImGui::PopStyleColor();
 		}
 
@@ -375,13 +372,13 @@ static void wireless_warning_popup() {
 	}
 
 	if (ImGui::BeginPopupModal("Wireless connection detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 400.f * settings.display.uiScale);
+		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
 		ImGui::TextWrapped("  Please use LAN cable for the best gameplay experience!  ");
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * settings.display.uiScale, 3 * settings.display.uiScale));
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
 
-		ImGui::SetCursorPosX((currentwidth - 100.f * settings.display.uiScale) / 2.f + ImGui::GetStyle().WindowPadding.x);
-		if (ImGui::Button("OK", ImVec2(100.f * settings.display.uiScale, 0.f))) {
+		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x);
+		if (ImGui::Button("OK", ScaledVec2(100.f, 0.f))) {
 			ImGui::CloseCurrentPopup();
 		}
 		ImGui::SetItemDefaultFocus();
@@ -390,18 +387,27 @@ static void wireless_warning_popup() {
 	}
 	
 	if (show_wireless_warning && no_popup_opened && connection_medium == "VPN") {
-		ImGui::OpenPopup("VPN connection detected");
+		ImGui::OpenPopup("Possible VPN / virtual network detected");
 		show_wireless_warning = false;
 	}
 	
-	if (ImGui::BeginPopupModal("VPN connection detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 400.f * settings.display.uiScale);
-		ImGui::TextWrapped("  Please DO NOT use VPN!  ");
-		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16 * settings.display.uiScale, 3 * settings.display.uiScale));
+	ImGui::SetNextWindowSizeConstraints(ScaledVec2(400.f, 0.f), ImVec2(FLT_MAX, FLT_MAX));
+	if (ImGui::BeginPopupModal("Possible VPN / virtual network detected", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
+		
+		ImGui::SetCursorPosX(ImGui::GetCursorPos().x + uiScaled(6.f));
+		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f - 12.f));
+		ImGui::TextWrapped(
+						   "Your connection appears to use a VPN or virtual network interface.\n"
+						   "This may cause latency or instability.\n"
+						   "Please disable VPNs or use a direct network connection."
+						   );
+		ImGui::PopTextWrapPos();
+		
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
 		
-		ImGui::SetCursorPosX((currentwidth - 100.f * settings.display.uiScale) / 2.f + ImGui::GetStyle().WindowPadding.x);
-		if (ImGui::Button("OK", ImVec2(100.f * settings.display.uiScale, 0.f))) {
+		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x);
+		if (ImGui::Button("OK", ScaledVec2(100.f, 0.f))) {
 			ImGui::CloseCurrentPopup();
 		}
 		ImGui::SetItemDefaultFocus();

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -451,7 +451,7 @@ std::string os_GetConnectionMedium(){
 		if (dwIfIndex == 0) return false;
 		MIB_IF_ROW2 row{};
 		row.InterfaceIndex = dwIfIndex;
-		if (NOERROR == GetIfEntry2(&row)) {
+		if (NO_ERROR == GetIfEntry2(&row)) {
 			auto has_vpn_keyword = [](const wchar_t* s) {
 				if (!s) return false;
 				std::wstring u(s);
@@ -463,6 +463,7 @@ std::string os_GetConnectionMedium(){
 						u.find(L"WAN MINIPORT") != std::wstring::npos ||
 						u.find(L"TUNNEL") != std::wstring::npos;
 			};
+
 			if (row.Type == IF_TYPE_TUNNEL || row.Type == IF_TYPE_PPP || row.Type == IF_TYPE_PROP_VIRTUAL || has_vpn_keyword(row.Description) || has_vpn_keyword(row.Alias)) {
 				result = "VPN";
 				nowide::stackstring name;

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -435,69 +435,85 @@ std::string os_GetMachineID()
 
 std::string os_GetConnectionMedium(){
 	std::string result = "Unknown";
-	DWORD dwIfIndex = 0;
 
+	DWORD dwIfIndex4 = 0;
+	GetBestInterface(inet_addr("8.8.8.8"), &dwIfIndex4);
+	
+	DWORD dwIfIndex6 = 0;
 	sockaddr_in6 addr6{};
 	addr6.sin6_family = AF_INET6;
 	// Google DNS IPv6: 2001:4860:4860::8888
 	const unsigned char google_dns_ipv6[] = { 0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x88 };
 	memcpy(&addr6.sin6_addr, google_dns_ipv6, 16);
-	if (NO_ERROR != GetBestInterfaceEx((sockaddr*)&addr6, &dwIfIndex)) {
-		// Fallback to IPv4
-		if (NO_ERROR != GetBestInterface(inet_addr("8.8.8.8"), &dwIfIndex))
-			return result;
-	}
+	GetBestInterfaceEx((sockaddr*)&addr6, &dwIfIndex6);
 
+	auto check_vpn = [&](DWORD dwIfIndex) -> bool {
+		if (dwIfIndex == 0) return false;
+		MIB_IF_ROW2 row{};
+		row.InterfaceIndex = dwIfIndex;
+		if (NOERROR == GetIfEntry2(&row)) {
+			auto has_vpn_keyword = [](const wchar_t* s) {
+				if (!s) return false;
+				std::wstring u(s);
+				for (auto& c : u) c = (wchar_t)std::towupper(c);
+				return  u.find(L"VPN") != std::wstring::npos ||
+						u.find(L"WIREGUARD") != std::wstring::npos ||
+						u.find(L"WINTUN") != std::wstring::npos ||
+						u.find(L"TAP-") != std::wstring::npos ||
+						u.find(L"WAN MINIPORT") != std::wstring::npos ||
+						u.find(L"TUNNEL") != std::wstring::npos;
+			};
+			if (row.Type == IF_TYPE_TUNNEL || row.Type == IF_TYPE_PPP || row.Type == IF_TYPE_PROP_VIRTUAL || has_vpn_keyword(row.Description) || has_vpn_keyword(row.Alias)) {
+				result = "VPN";
+				nowide::stackstring name;
+				if (row.Alias[0] && has_vpn_keyword(row.Alias))
+					name.convert(row.Alias);
+				else
+					name.convert(row.Description);
+				if (name.get() && name.get()[0])
+					result = "VPN: " + std::string(name.get());
+				return true;
+			}
+		}
+		return false;
+	};
+	if (check_vpn(dwIfIndex6) || check_vpn(dwIfIndex4))
+		return result;
+
+	DWORD dwIfIndex = dwIfIndex6 != 0 ? dwIfIndex6 : dwIfIndex4;
+	if (dwIfIndex == 0) return result;
 	MIB_IF_ROW2 row{};
 	row.InterfaceIndex = dwIfIndex;
 
 	if (NOERROR == GetIfEntry2(&row)) {
-		auto has_vpn_keyword = [](const wchar_t* s) {
-			if (!s) return false;
-			std::wstring u(s);
-			for (auto& c : u) c = (wchar_t)std::towupper(c);
-			return	u.find(L"VPN")			!= std::wstring::npos ||
-					u.find(L"WIREGUARD")	!= std::wstring::npos ||
-					u.find(L"TAP")			!= std::wstring::npos ||
-					u.find(L"TUN")			!= std::wstring::npos;
-		};
-
-		if (row.Type == IF_TYPE_TUNNEL || row.Type == IF_TYPE_PPP || row.Type == IF_TYPE_PROP_VIRTUAL || has_vpn_keyword(row.Description) || has_vpn_keyword(row.Alias) )
-		{
-			result = "VPN";
-		}
-		else
-		{
-			switch(row.PhysicalMediumType) {
-				case NdisPhysicalMediumWirelessLan:
-				case NdisPhysicalMediumWirelessWan:
-				case NdisPhysicalMediumNative802_11:
-				case NdisPhysicalMediumBluetooth:
-				case NdisPhysicalMediumWiMax:
-				case NdisPhysicalMediumUWB:
-				case NdisPhysicalMediumIrda:
-					result = "Wireless";
-					break;
-				case NdisPhysicalMediumCableModem:
-				case NdisPhysicalMediumPhoneLine:
-				case NdisPhysicalMediumPowerLine:
-				case NdisPhysicalMediumDSL:
-				case NdisPhysicalMediumFibreChannel:
-				case NdisPhysicalMedium1394:
-				case NdisPhysicalMediumInfiniband:
-				case NdisPhysicalMedium802_3:
-				case NdisPhysicalMedium802_5:
-				case NdisPhysicalMediumWiredWAN:
-				case NdisPhysicalMediumWiredCoWan:
-					result = "Wired";
-					break;
-				default:
-    			// leave as "Unknown"
-    			break;
-			}
+		switch(row.PhysicalMediumType) {
+			case NdisPhysicalMediumWirelessLan:
+			case NdisPhysicalMediumWirelessWan:
+			case NdisPhysicalMediumNative802_11:
+			case NdisPhysicalMediumBluetooth:
+			case NdisPhysicalMediumWiMax:
+			case NdisPhysicalMediumUWB:
+			case NdisPhysicalMediumIrda:
+				result = "Wireless";
+				break;
+			case NdisPhysicalMediumCableModem:
+			case NdisPhysicalMediumPhoneLine:
+			case NdisPhysicalMediumPowerLine:
+			case NdisPhysicalMediumDSL:
+			case NdisPhysicalMediumFibreChannel:
+			case NdisPhysicalMedium1394:
+			case NdisPhysicalMediumInfiniband:
+			case NdisPhysicalMedium802_3:
+			case NdisPhysicalMedium802_5:
+			case NdisPhysicalMediumWiredWAN:
+			case NdisPhysicalMediumWiredCoWan:
+				result = "Wired";
+				break;
+			default:
+				// leave as "Unknown"
+				break;
 		}
 	}
-
 	return result;
 }
 

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -59,6 +59,7 @@
 
 #include <windows.h>
 #include <windowsx.h>
+#include <cwctype>
 
 // Gdxsv
 #include <fstream>
@@ -433,53 +434,71 @@ std::string os_GetMachineID()
 }
 
 std::string os_GetConnectionMedium(){
-    std::string result = "Unknown";
-    DWORD dwIfIndex;
-    if (NO_ERROR != GetBestInterface (inet_addr ("8.8.8.8"), &dwIfIndex))
-        return result;
+	std::string result = "Unknown";
+	DWORD dwIfIndex = 0;
 
-    PMIB_IF_TABLE2 table = NULL;
-    if (NOERROR != GetIfTable2Ex(MibIfTableRaw, &table) )
-        return result;
+	sockaddr_in6 addr6{};
+	addr6.sin6_family = AF_INET6;
+	// Google DNS IPv6: 2001:4860:4860::8888
+	const unsigned char google_dns_ipv6[] = { 0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x88 };
+	memcpy(&addr6.sin6_addr, google_dns_ipv6, 16);
+	if (NO_ERROR != GetBestInterfaceEx((sockaddr*)&addr6, &dwIfIndex)) {
+		// Fallback to IPv4
+		if (NO_ERROR != GetBestInterface(inet_addr("8.8.8.8"), &dwIfIndex))
+			return result;
+	}
 
-    MIB_IF_ROW2 row;
-    ZeroMemory(&row, sizeof(MIB_IF_ROW2));
+	MIB_IF_ROW2 row{};
+	row.InterfaceIndex = dwIfIndex;
 
-    row.InterfaceIndex = dwIfIndex;
+	if (NOERROR == GetIfEntry2(&row)) {
+		auto has_vpn_keyword = [](const wchar_t* s) {
+			if (!s) return false;
+			std::wstring u(s);
+			for (auto& c : u) c = (wchar_t)std::towupper(c);
+			return	u.find(L"VPN")			!= std::wstring::npos ||
+					u.find(L"WIREGUARD")	!= std::wstring::npos ||
+					u.find(L"TAP")			!= std::wstring::npos ||
+					u.find(L"TUN")			!= std::wstring::npos;
+		};
 
-    if (NOERROR == GetIfEntry2(&row)) {
-        switch(row.PhysicalMediumType) {
-            case NdisPhysicalMediumWirelessLan:
-            case NdisPhysicalMediumWirelessWan:
-            case NdisPhysicalMediumNative802_11:
-            case NdisPhysicalMediumBluetooth:
-            case NdisPhysicalMediumWiMax:
-            case NdisPhysicalMediumUWB:
-            case NdisPhysicalMediumIrda:
-                result = "Wireless";
-                break;
-            case NdisPhysicalMediumCableModem:
-            case NdisPhysicalMediumPhoneLine:
-            case NdisPhysicalMediumPowerLine:
-            case NdisPhysicalMediumDSL:
-            case NdisPhysicalMediumFibreChannel:
-            case NdisPhysicalMedium1394:
-            case NdisPhysicalMediumInfiniband:
-            case NdisPhysicalMedium802_3:
-            case NdisPhysicalMedium802_5:
-            case NdisPhysicalMediumWiredWAN:
-            case NdisPhysicalMediumWiredCoWan:
-                result = "Wired";
-                break;
+		if (row.Type == IF_TYPE_TUNNEL || row.Type == IF_TYPE_PPP || row.Type == IF_TYPE_PROP_VIRTUAL || has_vpn_keyword(row.Description) || has_vpn_keyword(row.Alias) )
+		{
+			result = "VPN";
+		}
+		else
+		{
+			switch(row.PhysicalMediumType) {
+				case NdisPhysicalMediumWirelessLan:
+				case NdisPhysicalMediumWirelessWan:
+				case NdisPhysicalMediumNative802_11:
+				case NdisPhysicalMediumBluetooth:
+				case NdisPhysicalMediumWiMax:
+				case NdisPhysicalMediumUWB:
+				case NdisPhysicalMediumIrda:
+					result = "Wireless";
+					break;
+				case NdisPhysicalMediumCableModem:
+				case NdisPhysicalMediumPhoneLine:
+				case NdisPhysicalMediumPowerLine:
+				case NdisPhysicalMediumDSL:
+				case NdisPhysicalMediumFibreChannel:
+				case NdisPhysicalMedium1394:
+				case NdisPhysicalMediumInfiniband:
+				case NdisPhysicalMedium802_3:
+				case NdisPhysicalMedium802_5:
+				case NdisPhysicalMediumWiredWAN:
+				case NdisPhysicalMediumWiredCoWan:
+					result = "Wired";
+					break;
+				default:
+    			// leave as "Unknown"
+    			break;
+			}
+		}
+	}
 
-          default:
-                result = "Unspecified";
-        }
-
-    }
-    FreeMibTable(table);
-
-    return result;
+	return result;
 }
 
 void os_RunInstance(int argc, const char *argv[])

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -219,58 +219,57 @@ std::string os_GetMachineID(){
     return "";
 }
 
-NSString* runCommand(NSString* commandToRun) {
-    NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath:@"/bin/sh"];
-
-    NSArray *arguments = [NSArray arrayWithObjects:
-                          @"-c" ,
-                          [NSString stringWithFormat:@"%@", commandToRun],
-                          nil];
-    [task setArguments:arguments];
-
-    NSPipe *pipe = [NSPipe pipe];
-    [task setStandardOutput:pipe];
-
-    NSFileHandle *file = [pipe fileHandleForReading];
-
-    [task launch];
-
-    NSData *data = [file readDataToEndOfFile];
-
-    NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    return output;
-}
-
 std::string os_GetConnectionMedium() {
-    NSString* bestInterface = runCommand(@"route -n get 8.8.8.8 | grep interface | awk '{split($0,a,\": \"); printf \"%s\", a[2]}'");
+	std::string result = "Unknown";
+	@autoreleasepool {
+		SCDynamicStoreRef store = NULL;
+		CFPropertyListRef globalList = NULL;
+		CFStringRef setupKey = NULL;
+		CFPropertyListRef setupDict = NULL;
+		NSString* bestInterface = nil;
+		NSString* serviceID = nil;
+		NSString* hardware = nil;
 
-	if ( bestInterface == nil || [bestInterface isEqual:[NSNull null]] || ([bestInterface respondsToSelector:@selector(length)] && [bestInterface length] == 0)) {
-		return "Unknown";
+		store = SCDynamicStoreCreate(NULL, CFSTR("flycast"), NULL, NULL);
+		if (!store) goto done;
+
+		globalList = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv6"));
+		if (!globalList)
+			globalList = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4"));
+		if (!globalList) goto done;
+
+		bestInterface = [(NSDictionary *)globalList objectForKey:@"PrimaryInterface"];
+		if ([bestInterface length] == 0) goto done;
+		
+		if ([bestInterface hasPrefix:@"utun"] || [bestInterface hasPrefix:@"ppp"] || [bestInterface hasPrefix:@"tun"] || [bestInterface hasPrefix:@"vpn"]) {
+			result = "VPN";
+			goto done;
+		}
+
+		serviceID = [(NSDictionary *)globalList objectForKey:@"PrimaryService"];
+		if (!serviceID) goto done;
+
+		setupKey = SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainSetup, (CFStringRef)serviceID, kSCEntNetInterface);
+		if (!setupKey) goto done;
+
+		setupDict = SCDynamicStoreCopyValue(store, setupKey);
+		if (!setupDict) goto done;
+
+		hardware = [(NSDictionary *)setupDict objectForKey:(NSString *)kSCPropNetInterfaceHardware];
+		if ([hardware isEqualToString:@"AirPort"] || [hardware isEqualToString:@"Bluetooth"] || [hardware isEqualToString:@"IrDA"]) {
+			result = "Wireless";
+		} else if ([hardware isEqualToString:@"Ethernet"]) {
+			result = "Wired";
+		}
+
+	done:
+		[(id)setupDict release];
+		[(id)setupKey release];
+		[(id)globalList release];
+		[(id)store release];
 	}
-	
-	if ([bestInterface hasPrefix:@"utun"] || [bestInterface hasPrefix:@"ppp"] || [bestInterface hasPrefix:@"tun"] || [bestInterface hasPrefix:@"vpn"]) {
-		return "VPN";
-	}
-	
-    CFArrayRef ref = SCNetworkInterfaceCopyAll();
-    NSArray* networkInterfaces = (__bridge NSArray *)(ref);
-    NSString* interfaceType = @"";
-    for(int i = 0; i < networkInterfaces.count; i++) {
-        SCNetworkInterfaceRef interface = (__bridge SCNetworkInterfaceRef)(networkInterfaces[i]);
-        NSString* bsdName = (NSString*) SCNetworkInterfaceGetBSDName(interface);
 
-        if([bestInterface isEqualToString:bsdName]){
-            interfaceType = ((NSString *)SCNetworkInterfaceGetInterfaceType(interface)) ;
-            break;
-        }
-    }
-
-    if ([interfaceType isEqualToString:@"IEEE80211"] || [interfaceType isEqualToString:@"Bluetooth"] || [interfaceType isEqualToString:@"IrDA"]) {
-        return "Wireless";
-    } else {
-        return "Wired";
-    }
+	return result;
 }
 
 void os_RunInstance(int argc, const char *argv[])

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -222,53 +222,86 @@ std::string os_GetMachineID(){
 std::string os_GetConnectionMedium() {
 	std::string result = "Unknown";
 	@autoreleasepool {
-		SCDynamicStoreRef store = NULL;
-		CFPropertyListRef globalList = NULL;
-		CFStringRef setupKey = NULL;
-		CFPropertyListRef setupDict = NULL;
-		NSString* bestInterface = nil;
-		NSString* serviceID = nil;
-		NSString* hardware = nil;
+		SCDynamicStoreRef store = SCDynamicStoreCreate(NULL, CFSTR("flycast"), NULL, NULL);
+		if (!store) return result;
 
-		store = SCDynamicStoreCreate(NULL, CFSTR("flycast"), NULL, NULL);
-		if (!store) goto done;
+		auto getVal = [&](CFStringRef key) -> id {
+			if (!key) return nil;
+			id val = (id)SCDynamicStoreCopyValue(store, key);
+			CFRelease(key);
+			return [val autorelease];
+		};
 
-		globalList = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv6"));
+		NSDictionary *ipv4Global = getVal(CFSTR("State:/Network/Global/IPv4"));
+		NSDictionary *ipv6Global = getVal(CFSTR("State:/Network/Global/IPv6"));
+
+		NSDictionary *globalList = nil;
+		for (NSDictionary *global : { ipv6Global, ipv4Global }) {
+			if (!global) continue;
+			NSString* interface = [global objectForKey:@"PrimaryInterface"];
+			if ([interface hasPrefix:@"utun"] || [interface hasPrefix:@"ppp"] || [interface hasPrefix:@"tun"] || [interface hasPrefix:@"vpn"]) {
+				result = "VPN";
+				globalList = global;
+				break;
+			}
+		}
+
 		if (!globalList)
-			globalList = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4"));
-		if (!globalList) goto done;
-
-		bestInterface = [(NSDictionary *)globalList objectForKey:@"PrimaryInterface"];
-		if ([bestInterface length] == 0) goto done;
+			globalList = ipv6Global ?: ipv4Global;
 		
-		if ([bestInterface hasPrefix:@"utun"] || [bestInterface hasPrefix:@"ppp"] || [bestInterface hasPrefix:@"tun"] || [bestInterface hasPrefix:@"vpn"]) {
-			result = "VPN";
-			goto done;
+		NSString *bestInterface = [globalList objectForKey:@"PrimaryInterface"];
+		NSString *serviceID = [globalList objectForKey:@"PrimaryService"];
+
+		if (result == "VPN" && bestInterface) {
+			NSArray *keys = (NSArray *)SCDynamicStoreCopyKeyList(store, CFSTR("Setup:/Network/Service/[^/]+$"));
+			NSString *bestMatch = nil;
+
+			for (NSString *key in [keys autorelease]) {
+				NSString *sID = [key lastPathComponent];
+				
+				NSDictionary *idict = getVal(SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainSetup, (CFStringRef)sID, kSCEntNetInterface));
+				NSString *type = [idict objectForKey:(NSString *)kSCPropNetInterfaceType];
+				NSString *dev = [idict objectForKey:(NSString *)kSCPropNetInterfaceDeviceName];
+				
+				if (!dev) {
+					NSDictionary *sdict = getVal(SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainState, (CFStringRef)sID, CFSTR("IPv4")))
+					                   ?: getVal(SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainState, (CFStringRef)sID, CFSTR("IPv6")));
+					dev = [sdict objectForKey:@"InterfaceName"];
+				}
+
+				if ([dev isEqualToString:bestInterface]) {
+					bestMatch = sID;
+					break;
+				}
+				
+				if (!([type isEqualToString:@"VPN"] || [type isEqualToString:@"PPP"])) continue;
+
+				SCNetworkConnectionRef conn = SCNetworkConnectionCreateWithServiceID(NULL, (CFStringRef)sID, NULL, NULL);
+				if (conn) {
+					if (SCNetworkConnectionGetStatus(conn) == kSCNetworkConnectionConnected)
+						bestMatch = bestMatch ?: sID;
+					CFRelease(conn);
+				}
+				if (bestMatch) break;
+			}
+
+			NSDictionary *nd = getVal(SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainSetup, (CFStringRef)bestMatch, NULL));
+			NSString *name = [nd objectForKey:(NSString *)kSCPropUserDefinedName];
+			if ([name length] > 0)
+				result = "VPN: " + std::string([name UTF8String]);
 		}
 
-		serviceID = [(NSDictionary *)globalList objectForKey:@"PrimaryService"];
-		if (!serviceID) goto done;
-
-		setupKey = SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainSetup, (CFStringRef)serviceID, kSCEntNetInterface);
-		if (!setupKey) goto done;
-
-		setupDict = SCDynamicStoreCopyValue(store, setupKey);
-		if (!setupDict) goto done;
-
-		hardware = [(NSDictionary *)setupDict objectForKey:(NSString *)kSCPropNetInterfaceHardware];
-		if ([hardware isEqualToString:@"AirPort"] || [hardware isEqualToString:@"Bluetooth"] || [hardware isEqualToString:@"IrDA"]) {
-			result = "Wireless";
-		} else if ([hardware isEqualToString:@"Ethernet"]) {
-			result = "Wired";
+		if ((result == "Unknown" || result == "VPN") && serviceID) {
+			NSDictionary *setupDict = getVal(SCDynamicStoreKeyCreateNetworkServiceEntity(NULL, kSCDynamicStoreDomainSetup, (CFStringRef)serviceID, kSCEntNetInterface));
+			NSString *hardware = [setupDict objectForKey:(NSString *)kSCPropNetInterfaceHardware];
+			if ([hardware isEqualToString:@"AirPort"] || [hardware isEqualToString:@"Bluetooth"] || [hardware isEqualToString:@"IrDA"])
+				result = "Wireless";
+			else if ([hardware isEqualToString:@"Ethernet"])
+				result = "Wired";
 		}
 
-	done:
-		[(id)setupDict release];
-		[(id)setupKey release];
-		[(id)globalList release];
-		[(id)store release];
+		CFRelease(store);
 	}
-
 	return result;
 }
 


### PR DESCRIPTION
Aligns macOS and Windows connection medium detection so that both would now

- Support IPv6
- Detect VPN
- Use native APIs instead of shell commands 

Refined VPN alert prompt message and refracted all `settings.display.uiScale` to `uiScaled`/`ScaledVec2`