### PR TITLE
Implement P2P connectivity diagnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1922,7 +1922,6 @@ target_sources(${PROJECT_NAME} PRIVATE
 
 target_include_directories(${PROJECT_NAME} PRIVATE
 		core/deps/gdxsv
-		core/deps/libjuice/src
 		core/deps/libjuice/include/juice
 		)
 target_sources(${PROJECT_NAME} PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1920,7 +1920,11 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/deps/protobuf-3.13.0/src/google/protobuf/wrappers.pb.cc
 		core/deps/protobuf-3.13.0/src/google/protobuf/wrappers.pb.h)
 
-target_include_directories(${PROJECT_NAME} PRIVATE core/deps/gdxsv)
+target_include_directories(${PROJECT_NAME} PRIVATE
+		core/deps/gdxsv
+		core/deps/libjuice/src
+		core/deps/libjuice/include/juice
+		)
 target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/gdx_rpc.h
 		core/gdxsv/gdxsv.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1920,10 +1920,6 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/deps/protobuf-3.13.0/src/google/protobuf/wrappers.pb.cc
 		core/deps/protobuf-3.13.0/src/google/protobuf/wrappers.pb.h)
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-		core/deps/gdxsv
-		core/deps/libjuice/include/juice
-		)
 target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/gdx_rpc.h
 		core/gdxsv/gdxsv.cpp
@@ -1950,6 +1946,8 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/gdxsv_key_display.h
 		core/gdxsv/gdxsv_network.cpp
 		core/gdxsv/gdxsv_network.h
+		core/gdxsv/juice_helper.c
+		core/gdxsv/juice_helper.h
 		core/gdxsv/gdxsv_patch.inc
 		core/gdxsv/gdxsv_prof.cpp
 		core/gdxsv/gdxsv_prof.h
@@ -1965,6 +1963,8 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/lbs_message.h
 		core/gdxsv/libs.h
 		core/gdxsv/mcs_message.h)
+
+set_source_files_properties(core/gdxsv/juice_helper.c PROPERTIES INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/core/deps/libjuice/include/juice")
 
 if(WIN32)
 	set(CMAKE_VS_SDK_INCLUDE_DIRECTORIES ${CUSTOM_INCLUDE_DIRECTORIES})

--- a/core/gdxsv/gdxsv.cpp
+++ b/core/gdxsv/gdxsv.cpp
@@ -339,19 +339,20 @@ std::vector<u8> Gdxsv::GeneratePlatformInfoPacket() {
 		}
 	}
 
-	if (future_is_ready(port_test_result_v4_)) {
-		ss << "port_test_v4=" << port_test_result_v4_.get() << "\n";
-	}
-
-	if (future_is_ready(upnp_result_)) {
-		ss << "upnp_result=" << upnp_result_.get() << "\n";
-		ss << "upnp_local_ip=" << upnp_.localAddress() << "\n";
-		ss << "upnp_public_ip=" << upnp_.externalAddress() << "\n";
-		ss << "upnp_local_ip_differ=" << static_cast<int>(lbs_net_.LocalIP() != std::string(upnp_.localAddress())) << "\n";
-		if (public_ipv4_.valid()) {
-			if (public_ipv4_.get().first) {
-				ss << "upnp_public_ip_differ=" << static_cast<int>(public_ipv4_.get().second != std::string(upnp_.externalAddress()))
-				   << "\n";
+	if (future_is_ready(p2p_feasibility_result_)) {
+		const auto& res = p2p_feasibility_result_.get();
+		ss << "port_test_v4=" << res.port_test_v4 << "\n";
+		
+		if (!res.upnp_result.empty() && upnp_.isInitialized()) {
+			ss << "upnp_result=" << res.upnp_result << "\n";
+			ss << "upnp_local_ip=" << upnp_.localAddress() << "\n";
+			ss << "upnp_public_ip=" << upnp_.externalAddress() << "\n";
+			ss << "upnp_local_ip_differ=" << static_cast<int>(lbs_net_.LocalIP() != std::string(upnp_.localAddress())) << "\n";
+			if (public_ipv4_.valid()) {
+				if (public_ipv4_.get().first) {
+					ss << "upnp_public_ip_differ=" << static_cast<int>(public_ipv4_.get().second != std::string(upnp_.externalAddress()))
+					<< "\n";
+				}
 			}
 		}
 	}
@@ -446,7 +447,6 @@ void Gdxsv::HandleRPC() {
 			if (lbs_net_.Connect(config::GdxLobbyServer, port)) {
 				netmode_ = NetMode::Lbs;
 				lbs_net_.Send(GeneratePlatformInfoPacket());
-				AddPortMapping();
 			} else {
 				netmode_ = NetMode::Offline;
 			}
@@ -535,9 +535,11 @@ void Gdxsv::HandleRPC() {
 
 void Gdxsv::StartPingTest() { gcp_ping_test_result_ = gcp_ping_test().share(); }
 
-void Gdxsv::StartUdpPortTest() {
+void Gdxsv::StartP2PFeasibilityTest() {
+	if (p2p_feasibility_result_.valid())
+		return;
 	if (config::GdxLocalPort != 0) {
-		port_test_result_v4_ = test_udp_port_connectivity(config::GdxLocalPort, false).share();
+		p2p_feasibility_result_ = test_p2p_feasibility(config::GdxLocalPort).share();
 	}
 }
 
@@ -583,23 +585,6 @@ void Gdxsv::NotifyWanPort() const {
 
 	udp.SendTo(buf, pkt.GetCachedSize(), remote);
 	udp.Close();
-}
-
-void Gdxsv::AddPortMapping() {
-	if (config::EnableUPnP) {
-		int port = config::GdxLocalPort;
-		if (upnp_.isMapped(port, false)) {
-			NOTICE_LOG(COMMON, "UPnP AddPortMapping port=%d is already mapped", port);
-			return;
-		}
-		upnp_result_ = std::async(std::launch::async, [this, port]() -> std::string {
-						   NOTICE_LOG(COMMON, "UPnP AddPortMapping port=%d", port);
-						   const bool ok = upnp_.Init() && upnp_.AddPortMapping(port, false);
-						   std::string result = ok ? "Success" : upnp_.getLastError();
-						   NOTICE_LOG(COMMON, "UPnP AddPortMapping port=%d %s", port, result.c_str());
-						   return result;
-					   }).share();
-	}
 }
 
 std::string Gdxsv::GenerateLoginKey() {

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -50,6 +50,8 @@ class Gdxsv {
 	void StartP2PFeasibilityTest();
 	std::shared_future<P2PFeasibility> P2PFeasibilityResult() const { return p2p_feasibility_result_; }
 	void FetchPublicIP();
+	std::shared_future<std::pair<bool, std::string>> PublicIPv4() const { return public_ipv4_; }
+	std::shared_future<std::pair<bool, std::string>> PublicIPv6() const { return public_ipv6_; }
 	void NotifyWanPort() const;
 	bool StartReplayFile(const char* path, int pov);
 	void StopReplay();

--- a/core/gdxsv/gdxsv.h
+++ b/core/gdxsv/gdxsv.h
@@ -45,7 +45,10 @@ class Gdxsv {
 	void StartPingTest();
 	std::string PingResult() const { return pingResult; }
 	void SetPingResult(const std::string& result) { pingResult = result; }
-	void StartUdpPortTest();
+	std::string P2PStatus() const { return p2pStatus; }
+	void SetP2PStatus(const std::string& status) { p2pStatus = status; }
+	void StartP2PFeasibilityTest();
+	std::shared_future<P2PFeasibility> P2PFeasibilityResult() const { return p2p_feasibility_result_; }
 	void FetchPublicIP();
 	void NotifyWanPort() const;
 	bool StartReplayFile(const char* path, int pov);
@@ -57,7 +60,6 @@ class Gdxsv {
 	MiniUPnP& UPnP() { return upnp_; }
 
    private:
-	void AddPortMapping();
 	static std::string GenerateLoginKey();
 	std::vector<u8> GeneratePlatformInfoPacket();
 	std::vector<u8> GenerateP2PMatchReportPacket();
@@ -72,14 +74,14 @@ class Gdxsv {
 	std::atomic<int> maxrebattle_;
 	std::string user_id_;
 	std::string pingResult = "Latency check...";
+	std::string p2pStatus;
 	std::map<std::string, u32> symbols_;
 	proto::GamePatchList patch_list_;
 	bool going_to_battle_ = false;
 
 	std::shared_future<std::map<std::string, int>> gcp_ping_test_result_;
 	std::shared_future<std::pair<bool, std::string>> public_ipv4_, public_ipv6_;
-	std::shared_future<std::string> upnp_result_;
-	std::shared_future<std::string> port_test_result_v4_;
+	std::shared_future<P2PFeasibility> p2p_feasibility_result_;
 
 	MiniUPnP upnp_;
 	GdxsvBackendTcp lbs_net_;

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -27,6 +27,7 @@ static void gdxsv_update_popup();
 static void gdxsv_texture_update_popup();
 static void wireless_warning_popup(const std::string& connection_medium);
 static void vpn_warning_toast(const std::string& connection_medium);
+static void p2p_connection_toast();
 
 bool gdxsv_enabled() { return gdxsv.Enabled(); }
 
@@ -53,7 +54,7 @@ void gdxsv_emu_start() {
 		} else {
 			gdxsv.StartPingTest();
 			gui_setState(GuiState::GdxsvLatencyCheck);
-			gdxsv.StartUdpPortTest();
+			gdxsv.StartP2PFeasibilityTest();
 			gdxsv.FetchPublicIP();
 		}
 	}
@@ -164,6 +165,8 @@ void gdxsv_emu_gui_display() {
 			gui_state = GuiState::Closed;
 			emu.start();
 		}
+		
+		p2p_connection_toast();
 	}
 }
 
@@ -173,7 +176,10 @@ void gdxsv_emu_apply_base_settings() { gdxsv_apply_base_settings(); }
 
 const char* gdxsv_emu_settings_text_for_preparing_font() { return gdxsv_gui_settings_text_for_preparing_font(); }
 
-void gdxsv_gui_display_osd() { gdxsv.DisplayOSD(); }
+void gdxsv_gui_display_osd() {
+	gdxsv.DisplayOSD();
+	p2p_connection_toast();
+}
 
 void gdxsv_crash_append_log(FILE* f) {
 	if (gdxsv.Enabled()) {
@@ -398,6 +404,7 @@ static void vpn_warning_toast(const std::string& connection_medium) {
 		bool active = false;
 		bool shown = false;
 		float timer = 6.0f;
+		u32 last_frame_id = 0;
 	};
 	static Toast vpnToast;
 	
@@ -408,7 +415,12 @@ static void vpn_warning_toast(const std::string& connection_medium) {
 	}
 	
 	static float anim = 0.f;
-	float dt = ImGui::GetIO().DeltaTime;
+	
+	u32 current_frame_id = (u32)ImGui::GetFrameCount();
+	bool should_update = (current_frame_id != vpnToast.last_frame_id);
+	vpnToast.last_frame_id = current_frame_id;
+
+	float dt = should_update ? ImGui::GetIO().DeltaTime : 0.f;
 
 	if (vpnToast.active && !vpnToast.shown)
 	{
@@ -464,6 +476,98 @@ static void vpn_warning_toast(const std::string& connection_medium) {
 		}
 		ImGui::End();
 		ImGui::PopStyleVar();
+	}
+}
+
+static void p2p_connection_toast() {
+	struct Toast {
+		bool shown = false;
+		float timer = 6.0f;
+		P2PFeasibility result;
+		u32 last_frame_id = 0;
+		bool test_finished = false;
+	};
+	static Toast p2pToast;
+	static float anim = 0.f;
+	auto future = gdxsv.P2PFeasibilityResult();
+	
+	if (p2pToast.shown || !future.valid())
+		return;
+	
+	// Prevent double-updating logic if called from both GUI and OSD in the same frame
+	u32 current_frame_id = (u32)ImGui::GetFrameCount();
+	bool should_update = (current_frame_id != p2pToast.last_frame_id);
+	p2pToast.last_frame_id = current_frame_id;
+
+	float dt = should_update ? ImGui::GetIO().DeltaTime : 0.f;
+
+	if (!p2pToast.shown)
+	{
+		if (p2pToast.timer > 0.f)
+		{
+			// Only count down if the test is actually finished
+			if (p2pToast.test_finished) {
+				p2pToast.timer -= dt;
+			}
+			anim = ImMin(anim + dt * 3.0f, 1.0f);
+		}
+		else
+		{
+			anim = ImMax(anim - dt * 3.0f, 0.0f);
+			if (anim <= 0.f)
+				p2pToast.shown = true;
+		}
+		
+		if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+			if (!p2pToast.test_finished) {
+				p2pToast.result = future.get();
+				p2pToast.test_finished = true;
+				p2pToast.timer = 6.0f; // Reset timer to show the final result
+			}
+		} else {
+			p2pToast.result.description = gdxsv.P2PStatus();
+			p2pToast.result.color = 0xFFFFFFFF;
+			p2pToast.timer = 6.0f; // Keep timer full while test is running
+		}
+	}
+
+	if (anim > 0.f)
+	{
+		ImGui::SetNextWindowBgAlpha(0.8f * anim);
+		float margin = uiScaled(24.0f);
+		
+		float slide = (p2pToast.timer > 0.f) ? ImLerp(-(uiScaled(300.0f) + margin), 0.0f, anim) : 0.0f;
+		ImGuiViewport* vp = ImGui::GetMainViewport();
+
+		ImVec2 pos;
+		pos.x = vp->WorkPos.x + margin + slide;
+		pos.y = vp->WorkPos.y + vp->WorkSize.y - margin;
+		
+		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, anim);
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ScaledVec2(10.0f, 10.0f));
+		ImGui::SetNextWindowPos(pos, ImGuiCond_Always, ImVec2(0.0f, 1.0f));
+		ImGui::SetNextWindowSizeConstraints(ScaledVec2(300.f, 0.f), ImVec2(FLT_MAX, FLT_MAX));
+
+		ImGuiWindowFlags flags =
+			ImGuiWindowFlags_NoDecoration |
+			ImGuiWindowFlags_NoMove |
+			ImGuiWindowFlags_AlwaysAutoResize |
+			ImGuiWindowFlags_NoFocusOnAppearing |
+			ImGuiWindowFlags_NoNav |
+			ImGuiWindowFlags_Tooltip;
+
+		if (ImGui::Begin("##P2PToast", nullptr, flags))
+		{
+			ImGui::Text("P2P Connectivity Test");
+			if (p2pToast.test_finished) {
+				ImGui::SameLine();
+				ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(p2pToast.result.color), "%s", p2pToast.result.status.c_str());
+			}
+			ImGui::Separator();
+			ImGui::TextWrapped("%s", p2pToast.result.description.c_str());
+		}
+		ImGui::End();
+		ImGui::PopStyleVar(2);
 	}
 }
 

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -54,8 +54,8 @@ void gdxsv_emu_start() {
 		} else {
 			gdxsv.StartPingTest();
 			gui_setState(GuiState::GdxsvLatencyCheck);
-			gdxsv.StartP2PFeasibilityTest();
 			gdxsv.FetchPublicIP();
+			gdxsv.StartP2PFeasibilityTest();
 		}
 	}
 }

--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -482,7 +482,7 @@ static void vpn_warning_toast(const std::string& connection_medium) {
 static void p2p_connection_toast() {
 	struct Toast {
 		bool shown = false;
-		float timer = 6.0f;
+		float timer = 0.0f;
 		P2PFeasibility result;
 		u32 last_frame_id = 0;
 		bool test_finished = false;
@@ -505,32 +505,30 @@ static void p2p_connection_toast() {
 	{
 		if (p2pToast.timer > 0.f)
 		{
-			// Only count down if the test is actually finished
-			if (p2pToast.test_finished) {
-				p2pToast.timer -= dt;
-			}
+			p2pToast.timer -= dt;
 			anim = ImMin(anim + dt * 3.0f, 1.0f);
 		}
-		else
+		else if (p2pToast.test_finished)
 		{
 			anim = ImMax(anim - dt * 3.0f, 0.0f);
 			if (anim <= 0.f)
 				p2pToast.shown = true;
 		}
-		
+
 		if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
 			if (!p2pToast.test_finished) {
 				p2pToast.result = future.get();
 				p2pToast.test_finished = true;
-				p2pToast.timer = 6.0f; // Reset timer to show the final result
+				
+				// Only start displaying the toast if there are connection issues
+				if (p2pToast.result.status_code == P2PStatus::Poor || p2pToast.result.status_code == P2PStatus::Blocked) {
+					p2pToast.timer = 6.0f; 
+				} else {
+					p2pToast.shown = true;
+				}
 			}
-		} else {
-			p2pToast.result.description = gdxsv.P2PStatus();
-			p2pToast.result.color = 0xFFFFFFFF;
-			p2pToast.timer = 6.0f; // Keep timer full while test is running
 		}
 	}
-
 	if (anim > 0.f)
 	{
 		ImGui::SetNextWindowBgAlpha(0.8f * anim);

--- a/core/gdxsv/gdxsv_gui_settings.cpp
+++ b/core/gdxsv/gdxsv_gui_settings.cpp
@@ -357,7 +357,7 @@ u8"網絡對戰用嘅 UDP Port。\n唔可以同其他程式/電腦用一樣嘅 P
 	}
 
 	if (ImGui::Button(t({ "Test Connectivity", u8"接続診断", u8"測試連線能力" }), ScaledVec2(buttonWidth, 0)) && !p2p_future.valid()) {
-		p2p_feasibility = { "Testing...", "Running diagnostics...", "", "", 0xFFFFFFFF };
+		p2p_feasibility = { P2PStatus::Testing, "Testing...", "Running diagnostics...", "", "", 0xFFFFFFFF };
 		p2p_future = test_p2p_feasibility(config::GdxLocalPort);
 	}
 	ImGui::SameLine();

--- a/core/gdxsv/gdxsv_gui_settings.cpp
+++ b/core/gdxsv/gdxsv_gui_settings.cpp
@@ -1,4 +1,4 @@
-﻿#include "gdxsv_gui_settings.h"
+#include "gdxsv_gui_settings.h"
 
 #include "gdxsv.h"
 #include "gdxsv_network.h"
@@ -348,18 +348,39 @@ u8"網絡對戰用嘅 UDP Port。\n唔可以同其他程式/電腦用一樣嘅 P
 	if (future_is_ready(v4_future)) {
 		v4_result = v4_future.get();
 	}
-	if (ImGui::Button(t({ "Test The Port", u8"ポート開放確認", u8"確認開 Port 成功" }), ScaledVec2(buttonWidth, 0)) && !v4_future.valid()) {
-		v4_result = "Please wait...";
-		v4_future = test_udp_port_connectivity(config::GdxLocalPort, false);
+	static P2PFeasibility p2p_feasibility;
+	static std::future<P2PFeasibility> p2p_future;
+	if (future_is_ready(p2p_future)) {
+		p2p_feasibility = p2p_future.get();
+	} else if (p2p_future.valid()) {
+		p2p_feasibility.description = gdxsv.P2PStatus();
+	}
+
+	if (ImGui::Button(t({ "Test Connectivity", u8"接続診断", u8"測試連線能力" }), ScaledVec2(buttonWidth, 0)) && !p2p_future.valid()) {
+		p2p_feasibility = { "Testing...", "Running diagnostics...", "", "", 0xFFFFFFFF };
+		p2p_future = test_p2p_feasibility(config::GdxLocalPort);
 	}
 	ImGui::SameLine();
 	ShowHelpMarker(t({
-"Test receiving data using this UDP port.\nIf this test fails, it may result in the inability to establish a match or an increase in communication latency",
-u8"設定されたUDPポートを使って外部からデータを受信できるかテストします。\nこのテストに失敗する場合、対戦が成立しないか通信遅延が増加する場合があります。",
-u8"測試個 Port 能否接收數據。\n如果此測試失敗，可能會導致對戰無法建立或增加通訊延遲。"
+"Analyzes your network for P2P play:\n\n"
+"OK (Direct): Ideal. Port Forwarding, UPnP, or Full Cone NAT detected.\n"
+"OK (Hole Punching): Good. Moderate NAT detected. Hole Punching supported.\n"
+"Limited (May use Relay): Restricted. Symmetric NAT detected. May require a relay peer to connect.",
+u8"P2P対戦に向けたネットワーク診断を行います:\n\n"
+"OK (Direct): 最適。手動ポート開放、UPnP、または Full Cone NAT を確認しました。\n"
+"OK (Hole Punching): 良好。Moderate NAT が検出されました。ホールパンチングが可能です。\n"
+"Limited (May use Relay): 不可。Symmetric NAT が検出されました。リレーが必要になる可能性があります。",
+u8"分析你嘅網絡 P2P 對戰能力:\n\n"
+"OK (Direct): 完美。檢測到已手動開放 Port、UPnP 或 Full Cone NAT。\n"
+"OK (Hole Punching): 良好。檢測到 Moderate NAT。支援 Hole Punching。\n"
+"Limited (May use Relay): 差。檢測到 Symmetric NAT。你可能需要其他玩家幫你 Relay。"
 		}));
-	ImGui::SameLine();
-	ImGui::Text("%s", v4_result.c_str());
+	if (!p2p_feasibility.status.empty()) {
+		ImGui::SameLine();
+		ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(p2p_feasibility.color), "%s ", p2p_feasibility.status.c_str());
+		ImGui::SameLine();
+		ImGui::Text("%s", p2p_feasibility.description.c_str());
+	}
 
 	OptionArrowButtons(
 		t({"Gdx Minimum Delay", u8"最小入力遅延", u8"最少輸入延遲"}), config::GdxMinDelay, 2, 6,

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -16,7 +16,7 @@
 // External C header uses 'class' as a parameter name
 extern "C" {
 #define class _class
-#include "stun.h"
+#include "libjuice/src/stun.h"
 #undef class
 }
 

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -145,26 +145,9 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 		P2PFeasibility res;
 		res.color = 0xFFFFFFFF; // White
 
-		// 1. Baseline NAT Detection (using a random port to avoid lingering mapping interference)
-		set_p2p_status("Trying UDP Hole Punching...", true);
-		std::string global_nat_type = "Unknown";
-		bool is_full_cone_capable = false;
-		{
-			UdpClient test_udp;
-			std::random_device rd;
-			std::mt19937 gen(rd());
-			std::uniform_int_distribution<> dist(49152, 65535);
-			int test_port = dist(gen);
-			if (test_udp.Bind(test_port)) {
-				int mp = 0;
-				global_nat_type = run_nat_mapping_test(test_udp, mp);
-				if (global_nat_type == "Cone") {
-					is_full_cone_capable = run_udp_reachability_test(test_udp, test_port);
-				}
-			}
-		}
 
-		set_p2p_status("Testing Open Port...");
+		// 1. Initial Check
+		set_p2p_status("Testing Open Port...", true);
 		UdpClient udp;
 		if (!udp.Bind(port)) {
 			res.status = "Unknown";
@@ -186,10 +169,6 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 				res.status = "OK (Direct)";
 				res.description = "UPnP";
 				res.color = 0xFF00FF00; // Green
-			} else if (is_full_cone_capable) {
-				res.status = "OK (Direct)";
-				res.description = "Open NAT (Full Cone)";
-				res.color = 0xFFFFFF00; // Cyan
 			} else {
 				res.status = "OK (Direct)";
 				res.description = "Port Forwarding / DMZ";
@@ -215,6 +194,26 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 			} else {
 				res.upnp_result = upnp.getLastError();
 				set_p2p_status("UPnP: Failed to add rule");
+			}
+		}
+
+		// 4. Baseline NAT Detection (using a random port to avoid lingering mapping interference)
+		std::string global_nat_type = "Unknown";
+		bool is_full_cone_capable = false;
+		
+		set_p2p_status("Detecting NAT type...");
+		{
+			UdpClient test_udp;
+			std::random_device rd;
+			std::mt19937 gen(rd());
+			std::uniform_int_distribution<> dist(49152, 65535);
+			int test_port = dist(gen);
+			if (test_udp.Bind(test_port)) {
+				int mp = 0;
+				global_nat_type = run_nat_mapping_test(test_udp, mp);
+				if (global_nat_type == "Cone") {
+					is_full_cone_capable = run_udp_reachability_test(test_udp, mp);
+				}
 			}
 		}
 

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -52,11 +52,8 @@ std::future<std::pair<bool, std::string>> get_public_ip_address(bool ipv6) {
 	});
 }
 
-static bool run_udp_reachability_test(UdpClient &udp, int port) {
-	auto public_addr_future = get_public_ip_address(false);
-	public_addr_future.wait();
-	auto [ok, myip] = public_addr_future.get();
-	if (!ok) return false;
+static bool run_udp_reachability_test(UdpClient &udp, int port, const std::string &myip) {
+	if (myip.empty()) return false;
 
 	std::vector<http::PostField> fields;
 	fields.emplace_back("addr", myip + ":" + std::to_string(port));
@@ -145,6 +142,12 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 		P2PFeasibility res;
 		res.color = 0xFFFFFFFF; // White
 
+		auto public_addr_future = gdxsv.PublicIPv4();
+		if (!public_addr_future.valid()) {
+			public_addr_future = get_public_ip_address(false).share();
+		}
+		public_addr_future.wait();
+		auto [ok, myip] = public_addr_future.get();
 
 		// 1. Initial Check
 		set_p2p_status("Testing Open Port...", true);
@@ -158,7 +161,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 		}
 
 		// 2. Virgin Reachability Check
-		bool virgin_reachability = run_udp_reachability_test(udp, port);
+		bool virgin_reachability = run_udp_reachability_test(udp, port, myip);
 		res.port_test_v4 = virgin_reachability ? "Success" : "Failed (Timeout)";
 
 		if (virgin_reachability) {
@@ -184,7 +187,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 			auto &upnp = gdxsv.UPnP();
 			if (upnp.Init() && upnp.AddPortMapping(port, false)) {
 				res.upnp_result = "Success";
-				if (run_udp_reachability_test(udp, port)) {
+				if (run_udp_reachability_test(udp, port, myip)) {
 					res.status = "OK (Direct)";
 					res.description = "UPnP";
 					res.color = 0xFF00FF00; // Green
@@ -212,7 +215,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 				int mp = 0;
 				global_nat_type = run_nat_mapping_test(test_udp, mp);
 				if (global_nat_type == "Cone") {
-					is_full_cone_capable = run_udp_reachability_test(test_udp, mp);
+					is_full_cone_capable = run_udp_reachability_test(test_udp, mp, myip);
 				}
 			}
 		}

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -13,6 +13,13 @@
 #include <sys/ioctl.h>
 #endif
 
+// External C header uses 'class' as a parameter name
+extern "C" {
+#define class _class
+#include "stun.h"
+#undef class
+}
+
 static std::vector<std::string> v4_urls = {"https://api.ipify.org", "https://ipv4.seeip.org"};
 
 static std::vector<std::string> v6_urls = {"https://api64.ipify.org", "https://api.seeip.org"};
@@ -45,50 +52,193 @@ std::future<std::pair<bool, std::string>> get_public_ip_address(bool ipv6) {
 	});
 }
 
-std::future<std::string> test_udp_port_connectivity(int port, bool ipv6) {
-	return std::async(std::launch::async, [port, ipv6]() -> std::string {
-		UdpClient udp;
-		if (!udp.Bind(port)) {
-			return "Bind failed";
-		}
+static bool run_udp_reachability_test(UdpClient &udp, int port) {
+	auto public_addr_future = get_public_ip_address(false);
+	public_addr_future.wait();
+	auto [ok, myip] = public_addr_future.get();
+	if (!ok) return false;
 
-		auto public_addr = get_public_ip_address(ipv6);
-		public_addr.wait();
-		auto [ok, msg] = public_addr.get();
+	std::vector<http::PostField> fields;
+	fields.emplace_back("addr", myip + ":" + std::to_string(port));
+	int rc = http::post("https://asia-northeast1-gdxsv-274515.cloudfunctions.net/udptest", fields);
+	if (!http::success(rc)) return false;
 
-		if (!ok) {
-			return msg;
+	for (int t = 0; t < 30; t++) {
+		char buf[128];
+		sockaddr_storage sender{};
+		socklen_t addrlen = sizeof(sockaddr_storage);
+		if (udp.RecvFrom(buf, sizeof(buf), &sender, &addrlen) > 0) {
+			if (std::string(buf, 5) == "Hello") return true;
 		}
+		sleep_us(100 * 1000);
+	}
+	return false;
+}
 
-		const auto myip = msg;
-		std::vector<u8> content;
-		std::string content_type;
-		std::vector<http::PostField> fields;
-		auto test_addr = myip + ":" + std::to_string(port);
-		if (ipv6) {
-			test_addr = "[" + myip + "]:" + std::to_string(port);
-		}
-		fields.emplace_back("addr", test_addr);
-		int rc = http::post("https://asia-northeast1-gdxsv-274515.cloudfunctions.net/udptest", fields);
-		if (!http::success(rc)) {
-			return "HTTP Request failed: " + std::to_string(rc);
-		}
-
-		for (int t = 0; t < 30; t++) {
-			char buf[128];
+static std::string run_nat_mapping_test(UdpClient &udp, int &mapped_port) {
+	auto get_mapped_addr = [&](const char *host, int port, addr_record_t &mapped) -> bool {
+		UdpRemote server;
+		if (!server.Open(host, port)) return false;
+		uint8_t tid[STUN_TRANSACTION_ID_SIZE];
+		for (int i = 0; i < STUN_TRANSACTION_ID_SIZE; i++) tid[i] = rand() & 0xFF;
+		uint8_t buf[512];
+		int len = stun_write_header(buf, sizeof(buf), STUN_CLASS_REQUEST, STUN_METHOD_BINDING, tid);
+		if (len <= 0) return false;
+		if (udp.SendTo((const char *)buf, len, server) <= 0) return false;
+		for (int t = 0; t < 20; t++) {
 			sockaddr_storage sender{};
 			socklen_t addrlen = sizeof(sockaddr_storage);
-			int n = udp.RecvFrom(buf, sizeof(buf), &sender, &addrlen);
-			if (0 < n) {
-				if (std::string(buf, 5) == "Hello") {
-					return "Success";
+			int n = udp.RecvFrom((char *)buf, sizeof(buf), &sender, &addrlen);
+			if (n > 0) {
+				stun_message_t msg{};
+				if (stun_read(buf, n, &msg) >= 0 && msg.msg_class == STUN_CLASS_RESP_SUCCESS) {
+					if (memcmp(msg.transaction_id, tid, STUN_TRANSACTION_ID_SIZE) == 0) {
+						mapped = msg.mapped;
+						return true;
+					}
 				}
 			}
-
 			sleep_us(100 * 1000);
 		}
+		return false;
+	};
 
-		return "Failed (Timeout)";
+	addr_record_t addr1{}, addr2{};
+	bool ok1 = get_mapped_addr("stun.l.google.com", 19302, addr1);
+	bool ok2 = get_mapped_addr("stun.cloudflare.com", 3478, addr2);
+	if (!ok1 || !ok2) return "Timeout";
+
+	int port1 = 0, port2 = 0;
+	if (addr1.addr.ss_family == AF_INET) port1 = ntohs(((sockaddr_in *)&addr1.addr)->sin_port);
+	if (addr2.addr.ss_family == AF_INET) port2 = ntohs(((sockaddr_in *)&addr2.addr)->sin_port);
+
+	mapped_port = port1;
+	return (port1 == port2) ? "Cone" : "Symmetric";
+}
+
+static std::chrono::steady_clock::time_point last_p2p_update;
+
+static void set_p2p_status(const std::string& status, bool first = false) {
+	if (first) {
+		last_p2p_update = std::chrono::steady_clock::now();
+	} else {
+		auto now = std::chrono::steady_clock::now();
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_p2p_update).count();
+		if (elapsed < 500) {
+			sleep_us((500 - elapsed) * 1000);
+		}
+		last_p2p_update = std::chrono::steady_clock::now();
+	}
+	gdxsv.SetP2PStatus(status);
+}
+
+static void wait_p2p_status() {
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_p2p_update).count();
+	if (elapsed < 500) {
+		sleep_us((500 - elapsed) * 1000);
+	}
+}
+
+std::future<P2PFeasibility> test_p2p_feasibility(int port) {
+	return std::async(std::launch::async, [port]() -> P2PFeasibility {
+		P2PFeasibility res;
+		res.color = 0xFFFFFFFF; // White
+
+		// 1. Baseline NAT Detection (using a random port to avoid lingering mapping interference)
+		set_p2p_status("Trying UDP Hole Punching...", true);
+		std::string global_nat_type = "Unknown";
+		bool is_full_cone_capable = false;
+		{
+			UdpClient test_udp;
+			std::random_device rd;
+			std::mt19937 gen(rd());
+			std::uniform_int_distribution<> dist(49152, 65535);
+			int test_port = dist(gen);
+			if (test_udp.Bind(test_port)) {
+				int mp = 0;
+				global_nat_type = run_nat_mapping_test(test_udp, mp);
+				if (global_nat_type == "Cone") {
+					is_full_cone_capable = run_udp_reachability_test(test_udp, test_port);
+				}
+			}
+		}
+
+		set_p2p_status("Testing Open Port...");
+		UdpClient udp;
+		if (!udp.Bind(port)) {
+			res.status = "Unknown";
+			res.description = "Bind failed";
+			res.port_test_v4 = "Bind failed";
+			wait_p2p_status();
+			return res;
+		}
+
+		// 2. Virgin Reachability Check
+		bool virgin_reachability = run_udp_reachability_test(udp, port);
+		res.port_test_v4 = virgin_reachability ? "Success" : "Failed (Timeout)";
+
+		if (virgin_reachability) {
+			auto &upnp = gdxsv.UPnP();
+			upnp.Term(); // Force refresh of lanAddress by triggering re-init in CheckPortMapping
+			if (upnp.CheckPortMapping(port, false)) {
+				res.upnp_result = "Success";
+				res.status = "OK (Direct)";
+				res.description = "UPnP";
+				res.color = 0xFF00FF00; // Green
+			} else if (is_full_cone_capable) {
+				res.status = "OK (Direct)";
+				res.description = "Open NAT (Full Cone)";
+				res.color = 0xFFFFFF00; // Cyan
+			} else {
+				res.status = "OK (Direct)";
+				res.description = "Port Forwarding / DMZ";
+				res.color = 0xFF00FF00; // Green
+			}
+			wait_p2p_status();
+			return res;
+		}
+
+		// 3. Try to activate UPnP
+		if (config::EnableUPnP) {
+			set_p2p_status("Adding UPnP rule to your router...");
+			auto &upnp = gdxsv.UPnP();
+			if (upnp.Init() && upnp.AddPortMapping(port, false)) {
+				res.upnp_result = "Success";
+				if (run_udp_reachability_test(udp, port)) {
+					res.status = "OK (Direct)";
+					res.description = "UPnP";
+					res.color = 0xFF00FF00; // Green
+					wait_p2p_status();
+					return res;
+				}
+			} else {
+				res.upnp_result = upnp.getLastError();
+				set_p2p_status("UPnP: Failed to add rule");
+			}
+		}
+
+		// 4. Final Classification based on baseline NAT test
+		if (is_full_cone_capable) {
+			res.status = "OK (Direct)";
+			res.description = "Open NAT (Full Cone)";
+			res.color = 0xFFFFFF00; // Cyan
+		} else if (global_nat_type == "Cone") {
+			res.status = "OK (Hole Punching)";
+			res.description = "Moderate NAT (Restricted Cone)";
+			res.color = 0xFFFFFF00; // Cyan
+		} else if (global_nat_type == "Symmetric") {
+			res.status = "Limited (May use Relay)";
+			res.description = "Strict NAT (Symmetric)";
+			res.color = 0xFF0000FF; // Red
+		} else {
+			res.status = "Unknown";
+			res.description = "UDP Error / Blocked";
+			res.color = 0xFF888888;
+		}
+
+		wait_p2p_status();
+		return res;
 	});
 }
 

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -141,6 +141,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 	return std::async(std::launch::async, [port]() -> P2PFeasibility {
 		P2PFeasibility res;
 		res.color = 0xFFFFFFFF; // White
+		res.status_code = P2PStatus::Blocked;
 
 		auto public_addr_future = gdxsv.PublicIPv4();
 		if (!public_addr_future.valid()) {
@@ -156,6 +157,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 			res.status = "Unknown";
 			res.description = "Bind failed";
 			res.port_test_v4 = "Bind failed";
+			res.status_code = P2PStatus::Blocked;
 			wait_p2p_status();
 			return res;
 		}
@@ -172,10 +174,12 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 				res.status = "OK (Direct)";
 				res.description = "UPnP";
 				res.color = 0xFF00FF00; // Green
+				res.status_code = P2PStatus::Optimal;
 			} else {
 				res.status = "OK (Direct)";
 				res.description = "Port Forwarding / DMZ";
 				res.color = 0xFF00FF00; // Green
+				res.status_code = P2PStatus::Optimal;
 			}
 			wait_p2p_status();
 			return res;
@@ -191,6 +195,7 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 					res.status = "OK (Direct)";
 					res.description = "UPnP";
 					res.color = 0xFF00FF00; // Green
+					res.status_code = P2PStatus::Optimal;
 					wait_p2p_status();
 					return res;
 				}
@@ -225,18 +230,22 @@ std::future<P2PFeasibility> test_p2p_feasibility(int port) {
 			res.status = "OK (Direct)";
 			res.description = "Open NAT (Full Cone)";
 			res.color = 0xFFFFFF00; // Cyan
+			res.status_code = P2PStatus::Optimal;
 		} else if (global_nat_type == "Cone") {
 			res.status = "OK (Hole Punching)";
 			res.description = "Moderate NAT (Restricted Cone)";
 			res.color = 0xFFFFFF00; // Cyan
+			res.status_code = P2PStatus::Fair;
 		} else if (global_nat_type == "Symmetric") {
 			res.status = "Limited (May use Relay)";
 			res.description = "Strict NAT (Symmetric)";
 			res.color = 0xFF0000FF; // Red
+			res.status_code = P2PStatus::Poor;
 		} else {
 			res.status = "Unknown";
 			res.description = "UDP Error / Blocked";
 			res.color = 0xFF888888;
+			res.status_code = P2PStatus::Blocked;
 		}
 
 		wait_p2p_status();

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -8,17 +8,11 @@
 #include "oslib/http_client.h"
 #include "sleep.h"
 #include "gdxsv.h"
+#include "juice_helper.h"
 
 #ifndef _WIN32
 #include <sys/ioctl.h>
 #endif
-
-// External C header uses 'class' as a parameter name
-extern "C" {
-#define class _class
-#include "libjuice/src/stun.h"
-#undef class
-}
 
 static std::vector<std::string> v4_urls = {"https://api.ipify.org", "https://ipv4.seeip.org"};
 
@@ -73,26 +67,39 @@ static bool run_udp_reachability_test(UdpClient &udp, int port, const std::strin
 }
 
 static std::string run_nat_mapping_test(UdpClient &udp, int &mapped_port) {
-	auto get_mapped_addr = [&](const char *host, int port, addr_record_t &mapped) -> bool {
+	auto get_mapped_addr = [&](const char *host, int port, juice_mapped_addr_t &mapped) -> bool {
 		UdpRemote server;
-		if (!server.Open(host, port)) return false;
-		uint8_t tid[STUN_TRANSACTION_ID_SIZE];
-		for (int i = 0; i < STUN_TRANSACTION_ID_SIZE; i++) tid[i] = rand() & 0xFF;
+		if (!server.Open(host, port, UdpRemote::IpPref::V4Only)) return false;
+		
+		auto same_sender_v4 = [&](const sockaddr_storage& sender, socklen_t addrlen) -> bool {
+			if (sender.ss_family != AF_INET) return false;
+			if (addrlen < (socklen_t)sizeof(sockaddr_in)) return false;
+			if (server.net_addr()->sa_family != AF_INET) return false;
+			
+			const auto* s = (const sockaddr_in*)&sender;
+			const auto* d = (const sockaddr_in*)server.net_addr();
+			
+			return s->sin_port == d->sin_port && s->sin_addr.s_addr == d->sin_addr.s_addr;
+		};
+
+		static thread_local std::mt19937 rng{std::random_device{}()};
+		std::uniform_int_distribution<int> dist(0, 255);
+		uint8_t tid[JUICE_STUN_TID_SIZE];
+		for (int i = 0; i < JUICE_STUN_TID_SIZE; i++) tid[i] = (uint8_t)dist(rng);
 		uint8_t buf[512];
-		int len = stun_write_header(buf, sizeof(buf), STUN_CLASS_REQUEST, STUN_METHOD_BINDING, tid);
+		int len = juice_stun_write_binding_request(buf, sizeof(buf), tid);
 		if (len <= 0) return false;
 		if (udp.SendTo((const char *)buf, len, server) <= 0) return false;
 		for (int t = 0; t < 20; t++) {
 			sockaddr_storage sender{};
-			socklen_t addrlen = sizeof(sockaddr_storage);
+			socklen_t addrlen = sizeof(sender);
 			int n = udp.RecvFrom((char *)buf, sizeof(buf), &sender, &addrlen);
 			if (n > 0) {
-				stun_message_t msg{};
-				if (stun_read(buf, n, &msg) >= 0 && msg.msg_class == STUN_CLASS_RESP_SUCCESS) {
-					if (memcmp(msg.transaction_id, tid, STUN_TRANSACTION_ID_SIZE) == 0) {
-						mapped = msg.mapped;
-						return true;
-					}
+				if (!same_sender_v4(sender, addrlen))
+					continue;
+				
+				if (juice_stun_parse_binding_response(buf, n, tid, &mapped) == 0) {
+					return true;
 				}
 			}
 			sleep_us(100 * 1000);
@@ -100,7 +107,7 @@ static std::string run_nat_mapping_test(UdpClient &udp, int &mapped_port) {
 		return false;
 	};
 
-	addr_record_t addr1{}, addr2{};
+	juice_mapped_addr_t addr1{}, addr2{};
 	bool ok1 = get_mapped_addr("stun.l.google.com", 19302, addr1);
 	bool ok2 = get_mapped_addr("stun.cloudflare.com", 3478, addr2);
 	if (!ok1 || !ok2) return "Timeout";
@@ -642,11 +649,15 @@ void TcpClient::Close() {
 	}
 }
 
-bool UdpRemote::Open(const char *host, int port) {
+bool UdpRemote::Open(const char *host, int port, IpPref pref) {
 	verify(0 < port && port < 65536);
 	addrinfo *res = nullptr;
 	addrinfo hints{};
-	hints.ai_family = AF_UNSPEC;	  // IPv4 or IPv6
+	switch (pref) {
+		case IpPref::V4Only: hints.ai_family = AF_INET; break;
+		case IpPref::V6Only: hints.ai_family = AF_INET6; break;
+		default:             hints.ai_family = AF_UNSPEC; break; // IPv4 or IPv6
+	}
 	hints.ai_socktype = SOCK_DGRAM;	  // UDP
 	hints.ai_flags = AI_NUMERICSERV;  // service is port no
 	char service[10] = {};

--- a/core/gdxsv/gdxsv_network.h
+++ b/core/gdxsv/gdxsv_network.h
@@ -8,7 +8,15 @@
 #include "network/net_platform.h"
 #include "types.h"
 
-std::future<std::string> test_udp_port_connectivity(int port, bool ipv6);
+struct P2PFeasibility {
+	std::string status;
+	std::string description;
+	std::string port_test_v4;
+	std::string upnp_result;
+	uint32_t color; // ABGR
+};
+
+std::future<P2PFeasibility> test_p2p_feasibility(int port);
 std::future<std::pair<bool, std::string>> get_public_ip_address(bool ipv6);
 std::future<std::map<std::string, int>> gcp_ping_test();
 int get_random_port_number();

--- a/core/gdxsv/gdxsv_network.h
+++ b/core/gdxsv/gdxsv_network.h
@@ -8,7 +8,16 @@
 #include "network/net_platform.h"
 #include "types.h"
 
+enum class P2PStatus {
+	Testing,
+	Optimal,    // Direct / UPnP / Full Cone
+	Fair,       // Restricted Cone (Hole Punching)
+	Poor,       // Symmetric NAT (Relay likely)
+	Blocked     // UDP blocked / Error
+};
+
 struct P2PFeasibility {
+	P2PStatus status_code = P2PStatus::Testing;
 	std::string status;
 	std::string description;
 	std::string port_test_v4;

--- a/core/gdxsv/gdxsv_network.h
+++ b/core/gdxsv/gdxsv_network.h
@@ -84,7 +84,8 @@ class MessageFilter {
 
 class UdpRemote {
    public:
-	bool Open(const char *host, int port);
+	enum class IpPref { Any, V4Only, V6Only };
+	bool Open(const char *host, int port, IpPref pref = IpPref::Any);
 	bool Open(const std::string &ip_port);
 	bool Open(const sockaddr *addr, socklen_t addrlen);
 	void Close();

--- a/core/gdxsv/juice_helper.c
+++ b/core/gdxsv/juice_helper.c
@@ -1,0 +1,32 @@
+#include "juice_helper.h"
+#include <string.h>
+
+#include "deps/libjuice/src/stun.h"
+
+int juice_stun_write_binding_request(void *buf, size_t size, const uint8_t tid[JUICE_STUN_TID_SIZE]) {
+    return stun_write_header(buf, size, STUN_CLASS_REQUEST, STUN_METHOD_BINDING, tid);
+}
+
+int juice_stun_parse_binding_response(void *buf, size_t size, 
+                                      const uint8_t expected_tid[JUICE_STUN_TID_SIZE], 
+                                      juice_mapped_addr_t *out) {
+    stun_message_t msg;
+    if (stun_read(buf, size, &msg) < 0) {
+        return -1;
+    }
+
+    if (msg.msg_class != STUN_CLASS_RESP_SUCCESS || msg.msg_method != STUN_METHOD_BINDING) {
+        return -1;
+    }
+
+    if (memcmp(msg.transaction_id, expected_tid, JUICE_STUN_TID_SIZE) != 0) {
+        return -1;
+    }
+
+    if (out) {
+        memcpy(&out->addr, &msg.mapped.addr, sizeof(struct sockaddr_storage));
+        out->len = msg.mapped.len;
+    }
+
+    return 0;
+}

--- a/core/gdxsv/juice_helper.h
+++ b/core/gdxsv/juice_helper.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#endif
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define JUICE_STUN_TID_SIZE 12
+
+typedef struct {
+    struct sockaddr_storage addr;
+    socklen_t len;
+} juice_mapped_addr_t;
+
+int juice_stun_write_binding_request(void *buf, size_t size, const uint8_t tid[JUICE_STUN_TID_SIZE]);
+
+int juice_stun_parse_binding_response(void *buf, size_t size, 
+                                      const uint8_t expected_tid[JUICE_STUN_TID_SIZE], 
+                                      juice_mapped_addr_t *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/core/network/miniupnp.cpp
+++ b/core/network/miniupnp.cpp
@@ -96,4 +96,27 @@ bool MiniUPnP::AddPortMapping(int port, bool tcp)
 	DEBUG_LOG(NETWORK, "MiniUPnP: forwarding %s port %d", tcp ? "TCP" : "UDP", port);
 	return true;
 }
+
+bool MiniUPnP::CheckPortMapping(int port, bool tcp)
+{
+	if (!initialized && !Init())
+		return false;
+
+	char internalClient[40];
+	char internalPort[10];
+	char duration[10];
+	char description[80];
+	char enabled[10];
+
+	int error = UPNP_GetSpecificPortMappingEntry(urls.controlURL, data.first.servicetype,
+		std::to_string(port).c_str(), tcp ? "TCP" : "UDP", nullptr,
+		internalClient, internalPort, description, enabled, duration);
+
+	if (error == 0) {
+		// Mapping exists. Check if it's for our IP.
+		return strcmp(internalClient, lanAddress) == 0;
+	}
+
+	return false;
+}
 #endif

--- a/core/network/miniupnp.h
+++ b/core/network/miniupnp.h
@@ -67,6 +67,7 @@ public:
 	bool Init() { return true; }
 	void Term() {}
 	bool AddPortMapping(int port, bool tcp) { return true; }
+	bool CheckPortMapping(int port, bool tcp);
 	const char *localAddress() const { return ""; }
 	const char *externalAddress() const { return ""; }
 	const char *getLastError() const { return ""; }

--- a/core/network/miniupnp.h
+++ b/core/network/miniupnp.h
@@ -40,6 +40,7 @@ public:
 	bool Init();
 	void Term();
 	bool AddPortMapping(int port, bool tcp);
+	bool CheckPortMapping(int port, bool tcp);
 	bool isMapped(int port, bool tcp) { return std::find(mappedPorts.begin(), mappedPorts.end(),
 		std::make_pair(std::to_string(port), tcp)) != mappedPorts.end(); }
 	const char *localAddress() const { return lanAddress; }


### PR DESCRIPTION
This PR introduces a new P2P Feasibility Test to provide a more accurate and informative diagnosis of NAT behavior and peer connectivity

- Add a P2P feasibility test to analyze NAT type
  - Full Cone
  - Restricted Cone
  - Symmetric
- Uses the new `libjuice`/`stun` integration for NAT mapping detection
- Use the toast style to display live diagnostic progress
![Feb-12-2026 02-24-04](https://github.com/user-attachments/assets/2d0f2403-e5ea-46ce-b489-b1e6a137005d)
![Feb-12-2026 02-24-55](https://github.com/user-attachments/assets/7445264d-8484-44d8-bdee-fa079060147c)

- Replace `StartUdpPortTest()` & `AddPortMapping()` with `StartP2PFeasibilityTest()`
  - `port_test_result_v4_` and `upnp_result_` are now derived from `test_p2p_feasibility` now
  - `StartP2PFeasibilityTest()` is executed once per session (similar to the latency checker)
- Replaced the `Test The Port` button in Settings also
<img width="588" height="153" alt="image" src="https://github.com/user-attachments/assets/4ff07520-77ba-4975-9c20-acbcaf3133b8" />



Background:
I’ve assisted several players with broken UPnP configurations. In some cases:
- Routers reported Restricted Cone NAT, but UDP hole punching would intermittently fail.
- Restarting the router temporarily restored hole punching functionality.
- UPnP remained unreliable or non-functional.
- Manual port forwarding consistently resolved the issue.

The main goal is to replace the `Test The Port` with a more informative P2P connectivity diagnostic, the connection check + toast is a non intrusive "nice to have" during game load.