### PR TITLE
Replay: fix crash in key display when history is empty

### DIFF
--- a/core/gdxsv/gdxsv_key_display.cpp
+++ b/core/gdxsv/gdxsv_key_display.cpp
@@ -59,6 +59,9 @@ void GdxsvKeyDisplay::DisplayOSD() {
 
 	const float w = ImGui::GetIO().DisplaySize.x;
 	const float h = ImGui::GetIO().DisplaySize.y;
+
+	if (history_[display_player_].empty()) return;
+
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0);
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
 	ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always,


### PR DESCRIPTION
Fix assertion failure in `GdxsvKeyDisplay::DisplayOSD` when there is no input history to display

In `GdxsvKeyDisplay::DisplayOSD`, the code was calling `ImGui::SetCursorPosY(100 * scale)` but then entering a for loop over `history_`. 
If the history was empty (which happens when a match ends or during a transition to a next battle), the loop wouldn't execute, no items would be drawn, and `ImGui::End()` would be called immediately.
This triggered the assertion:
`Code uses SetCursorPos()/SetCursorScreenPos() to extend window/parent boundaries. Please submit an item e.g. Dummy() afterwards...`

So we return before `SetCursorPosY` is called