### PR TITLE
Improve UDP connectivity robustness and fix socket pollution

### DIFF
--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -743,12 +743,13 @@ void UdpPingPong::Start(uint32_t session_id, uint8_t peer_id, int port, int dura
 		start_time_ = std::chrono::high_resolution_clock::now();
 
 		bool retried = false;
+		const int retry_timeout = 1000 + (peer_id * 250);
 
 		for (int loop_count = 0; running_; loop_count++) {
 			auto now = std::chrono::high_resolution_clock::now();
 			auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_).count();
 
-			if (!retried && elapsed_ms > 1000) {
+			if (!retried && elapsed_ms > retry_timeout) {
 				bool has_pong = false;
 				{
 					std::lock_guard<std::recursive_mutex> lock(mutex_);

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -599,6 +599,7 @@ bool UdpClient::Bind(int port) {
 		set_recv_timeout(sock, 1);
 		set_send_timeout(sock, 1);
 		set_non_blocking(sock);
+		set_udp_connreset(sock);
 
 		if (af == AF_INET) {
 			sock_v4_ = sock;
@@ -737,13 +738,45 @@ void UdpPingPong::Start(uint32_t session_id, uint8_t peer_id, int port, int dura
 	}
 
 	peer_id_ = peer_id;
-	std::thread([this, session_id, peer_id, duration_ms, network_delay]() {
+	std::thread([this, session_id, peer_id, port, duration_ms, network_delay]() {
 		WARN_LOG(COMMON, "Start UdpPingPong Thread");
 		start_time_ = std::chrono::high_resolution_clock::now();
+
+		bool retried = false;
 
 		for (int loop_count = 0; running_; loop_count++) {
 			auto now = std::chrono::high_resolution_clock::now();
 			auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_).count();
+
+			if (!retried && elapsed_ms > 1000) {
+				bool has_pong = false;
+				{
+					std::lock_guard<std::recursive_mutex> lock(mutex_);
+					for (const auto &c : candidates_) {
+						if (0 < c.pong_count) {
+							has_pong = true;
+							break;
+						}
+					}
+				}
+				if (!has_pong) {
+					NOTICE_LOG(COMMON, "No PONG received after 1000ms. Retrying with port %d", port + 1);
+					client_.Close();
+					if (client_.Bind(port + 1)) {
+						retried = true;
+						// Reset start_time to give the new port a full duration
+						start_time_ = std::chrono::high_resolution_clock::now();
+						elapsed_ms = 0;
+					} else {
+						ERROR_LOG(COMMON, "Retry bind failed");
+						// Continue with the failed socket or stop? 
+						// For now, let's just mark it as retried so we don't loop here.
+						retried = true;
+					}
+				} else {
+					retried = true;
+				}
+			}
 
 			while (true) {
 				Packet recv{};

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -738,46 +738,13 @@ void UdpPingPong::Start(uint32_t session_id, uint8_t peer_id, int port, int dura
 	}
 
 	peer_id_ = peer_id;
-	std::thread([this, session_id, peer_id, port, duration_ms, network_delay]() {
+	std::thread([this, session_id, peer_id, duration_ms, network_delay]() {
 		WARN_LOG(COMMON, "Start UdpPingPong Thread");
 		start_time_ = std::chrono::high_resolution_clock::now();
-
-		bool retried = false;
-		const int retry_timeout = 1000 + (peer_id * 250);
 
 		for (int loop_count = 0; running_; loop_count++) {
 			auto now = std::chrono::high_resolution_clock::now();
 			auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_).count();
-
-			if (!retried && elapsed_ms > retry_timeout) {
-				bool has_pong = false;
-				{
-					std::lock_guard<std::recursive_mutex> lock(mutex_);
-					for (const auto &c : candidates_) {
-						if (0 < c.pong_count) {
-							has_pong = true;
-							break;
-						}
-					}
-				}
-				if (!has_pong) {
-					NOTICE_LOG(COMMON, "No PONG received after 1000ms. Retrying with port %d", port + 1);
-					client_.Close();
-					if (client_.Bind(port + 1)) {
-						retried = true;
-						// Reset start_time to give the new port a full duration
-						start_time_ = std::chrono::high_resolution_clock::now();
-						elapsed_ms = 0;
-					} else {
-						ERROR_LOG(COMMON, "Retry bind failed");
-						// Continue with the failed socket or stop? 
-						// For now, let's just mark it as retried so we don't loop here.
-						retried = true;
-					}
-				} else {
-					retried = true;
-				}
-			}
 
 			while (true) {
 				Packet recv{};

--- a/core/network/net_platform.h
+++ b/core/network/net_platform.h
@@ -72,9 +72,22 @@ static inline int get_last_error() { return WSAGetLastError(); }
 #ifndef SHUT_RD
 #define SHUT_RD SD_RECEIVE
 #endif
+
+#ifndef SIO_UDP_CONNRESET
+#define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
+#endif
 #endif
 
 bool is_local_address(u32 addr);
+
+static inline void set_udp_connreset(sock_t fd)
+{
+#ifdef _WIN32
+	BOOL bNewBehavior = FALSE;
+	DWORD dwBytesReturned = 0;
+	WSAIoctl(fd, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL);
+#endif
+}
 
 static inline void set_non_blocking(sock_t fd)
 {

--- a/core/network/net_platform.h
+++ b/core/network/net_platform.h
@@ -76,6 +76,9 @@ static inline int get_last_error() { return WSAGetLastError(); }
 #ifndef SIO_UDP_CONNRESET
 #define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
 #endif
+#ifndef SIO_UDP_NETRESET
+#define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 11)
+#endif
 #endif
 
 bool is_local_address(u32 addr);
@@ -86,6 +89,7 @@ static inline void set_udp_connreset(sock_t fd)
 	BOOL bNewBehavior = FALSE;
 	DWORD dwBytesReturned = 0;
 	WSAIoctl(fd, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL);
+	WSAIoctl(fd, SIO_UDP_NETRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL);
 #endif
 }
 


### PR DESCRIPTION
 - Disable SIO_UDP_CONNRESET on Windows to prevent WSAECONNRESET (10054) errors from polluting the shared UDP socket when a peer is unreachable.
 - ~Implement a port-retry mechanism in UdpPingPong that attempts to re-bind to a different local port (port + 1) if no PONGs are received within the first 1000ms  (1000ms + PeerID * 250ms).~
- These changes address cases where local network interface issues or stale NAT mappings would otherwise cause a total connection failure, while maintaining backward compatibility with older clients.


```
{
  "insertId": "kl9ovkjd9n6wfuylo",
  "jsonPayload": {
    "disconnected_peer_id": 0,
    "message": "P2PMatchingReport",
    "peer_id": 0,
    "input_block_count_1": 0,
    "gdxsv_version": "v1.2.21",
    "addr": "182.xxx.xxx.xxx:31392",
    "battle_code": "1768408605335",
    "last_session_id": "11153732",
    "frame_count": 0,
    "gdxsv_revision": "277633d",
    "cpu": "x86/64",
    "caller": "gdxsv/lbs_handler.go:1705",
    "flycast": "gdxsv-1.8.0",
    "eventTime": "2026-01-15T01:37:17.412+0900",
    "player_count": 4,
    "before_log": "99:47:856 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:000 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:002 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:002 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:003 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:003 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:005 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:005 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:143 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:145 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:145 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:147 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:147 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:148 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:148 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:286 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:287 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:287 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:289 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:289 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:290 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:290 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:429 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:430 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:430 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:431 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:431 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:433 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:433 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:577 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:578 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:578 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:579 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:579 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:581 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:581 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:721 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:723 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:723 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:724 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:724 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:726 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:726 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:868 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:48:869 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:869 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:870 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:870 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:48:871 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:48:871 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:015 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:49:016 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:016 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:018 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:018 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:019 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:019 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:159 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:49:161 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:161 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:163 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:163 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:165 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:165 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:309 gdxsv/gdxsv_network.cpp:642 W[COMMON]: UDP Send failed. errno=10051
99:49:310 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:310 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:311 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:311 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:313 gdxsv/gdxsv_network.cpp:615 E[COMMON]: UDP4 Recv failed. errno=10054
99:49:313 gdxsv/gdxsv_network.cpp:625 E[COMMON]: UDP6 Recv failed. errno=10014
99:49:820 gdxsv/gdxsv_network.cpp:947 N[COMMON]: UdpPingTest Finish
99:49:820 gdxsv/gdxsv_network.cpp:948 N[COMMON]: RTT MATRIX
99:49:820 gdxsv/gdxsv_network.cpp:949 N[COMMON]:      0   1   2   3
99:49:820 gdxsv/gdxsv_network.cpp:951 N[COMMON]: 0>   0   0   0   0
99:49:820 gdxsv/gdxsv_network.cpp:951 N[COMMON]: 1>   0   0   0   0
99:49:820 gdxsv/gdxsv_network.cpp:951 N[COMMON]: 2>   0   0   0   0
99:49:820 gdxsv/gdxsv_network.cpp:951 N[COMMON]: 3>   0   0   0   0
99:49:820 gdxsv/gdxsv_network.cpp:954 N[COMMON]: CANDIDATES
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer1 JKF9GP: ping=49 pong=0 rtt=0.00 addr=221.xxx.xx.xxx:63473
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer1 JKF9GP: ping=49 pong=0 rtt=0.00 addr=192.xxx.xx.xx:63473
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer1 JKF9GP: ping=49 pong=0 rtt=0.00 addr=127.x.x.x:63473
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer2 GTK6GU: ping=49 pong=0 rtt=0.00 addr=211.xxx.xxx.xx:29715
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer2 GTK6GU: ping=49 pong=0 rtt=0.00 addr=192.xxx.x.xxx:29715
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer2 GTK6GU: ping=49 pong=0 rtt=0.00 addr=127.x.x.x:29715
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer3 32MO6N: ping=49 pong=0 rtt=0.00 addr=127.x.x.x:63856
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer3 32MO6N: ping=49 pong=0 rtt=0.00 addr=114.xxx.xx.xxx:63856
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer3 32MO6N: ping=49 pong=0 rtt=0.00 addr=192.xxx.x.x:63856
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer3 32MO6N: ping=49 pong=0 rtt=0.00 addr=[2400:4051:9322:xxx:xxxx:xxxx:xxxx:xxxx]:63856
99:49:820 gdxsv/gdxsv_network.cpp:956 N[COMMON]: [ ] Peer3 32MO6N: ping=49 pong=0 rtt=0.00 addr=114.xxx.xx.xxx:23728
99:49:820 gdxsv/gdxsv_network.cpp:868 N[COMMON]: End UdpPingPong Thread
99:50:355 gdxsv/gdxsv_backend_rollback.cpp:412 N[COMMON]: GdxsvBackendRollback.Open
99:50:438 gdxsv/gdxsv_backend_rollback.cpp:133 N[COMMON]: StopEmulator
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:144 N[COMMON]: StartGGPOSession
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:201 N[COMMON]: Peer count 4
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:204 N[COMMON]: Peer0 is self
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:228 N[COMMON]: Peer1 unreachable
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:228 N[COMMON]: Peer2 unreachable
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:228 N[COMMON]: Peer3 unreachable
99:50:498 gdxsv/gdxsv_backend_rollback.cpp:247 N[COMMON]: Network unreachable
",
...
```

Please note that this set of changes is specifically targeted at resolving catastrophic UDP socket failures (as seen in cases like Battle `1768408605335`), where local OS errors or stale NAT mappings cause a peer to become completely isolated.

What this does not fix:
Routing Inconsistency (e.g. Battle `1770655016432`): This PR does not yet address the "consensus" problem where two peers with asymmetric visibility might disagree on whether to use a direct or relayed path
