### PR TITLE
Replace replay round slider with discrete buttons

### DIFF
--- a/core/gdxsv/gdxsv_backend_replay.cpp
+++ b/core/gdxsv/gdxsv_backend_replay.cpp
@@ -9,6 +9,7 @@
 #include "ui/mainui.h"
 #include "gdx_rpc.h"
 #include "gdxsv.h"
+#include "gdxsv_translation.h"
 #include "gdxsv_replay_util.h"
 #include "input/gamepad_device.h"
 #include "libs.h"
@@ -58,7 +59,6 @@ void GdxsvBackendReplay::Reset() {
 	recv_delay_ = 0;
 	end_of_frame_ = false;
 	seeking_ = false;
-	pending_round_ = 0;
 	pause_menu_opend_ = false;
 	lbs_first_skip_ = false;
 	ctrl_play_speed_ = 0;
@@ -318,14 +318,7 @@ void GdxsvBackendReplay::OnNextFrame() {
 					}
 					verify(recv_buf_.empty());
 					gdxsv_save_state.SaveState(key_msg_count_);
-					pending_round_ = start_msg_count_;
 					NOTICE_LOG(COMMON, "Save Menu Opened frame %d", key_msg_count_);
-				} else {
-					// Apply pending round change on menu close
-					if (pending_round_ != 0 && pending_round_ != start_msg_count_) {
-						ctrl_commands_.emplace_back(ReplayCtrlCommand::SetRound, pending_round_);
-					}
-					pending_round_ = 0;
 				}
 				SDL_ShowCursor(pause_menu_opend_ ? SDL_ENABLE : SDL_DISABLE);
 			}
@@ -496,7 +489,7 @@ void GdxsvBackendReplay::OnNextFrame() {
 
 		if (ctrl.cmd == ReplayCtrlCommand::SetRound || ctrl.cmd == ReplayCtrlCommand::NextRound) {
 			const int round = ctrl.cmd == ReplayCtrlCommand::SetRound ? ctrl.arg1 : start_msg_count_ + ctrl.arg1;
-			if (0 < round && round != start_msg_count_ && round - 1 < log_file_.start_msg_indexes_size() &&
+			if (0 < round && round - 1 < log_file_.start_msg_indexes_size() &&
 				round - 1 < log_file_.start_msg_randoms_size() && gdxsv_save_state.FirstSavedFrame() != -1) {
 				gdxsv_save_state.LoadState(gdxsv_save_state.FirstSavedFrame());
 				key_msg_count_ = log_file_.start_msg_indexes(round - 1);
@@ -1271,18 +1264,87 @@ void GdxsvBackendReplay::RenderPauseMenu() {
 		}
 		ImGui::EndDisabled();
 
-		// Round control: slider
+		// Round control: buttons
 		if (ChangeRoundAvailable()) {
 			ImGui::Separator();
 
 			int roundStart, roundEnd, totalRounds;
 			GetRoundBounds(roundStart, roundEnd, totalRounds);
 
-			ImGui::AlignTextToFramePadding();
+			ImGui::BeginGroup();
+			float buttonHeight = uiScaled(40.0f);
+			float textHeight = ImGui::GetFontSize();
+			float initialY = ImGui::GetCursorPosY();
+
+			ImGui::SetCursorPosY(initialY + (buttonHeight - textHeight) * 0.5f);
 			ImGui::Text("Round");
 			ImGui::SameLine();
-			ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-			ImGui::SliderInt("##round", &pending_round_, 1, totalRounds, "%d");
+
+			for (int i = 1; i <= totalRounds; i++) {
+				ImGui::SetCursorPosY(initialY);
+				char label[16];
+				snprintf(label, sizeof(label), "%d", i);
+
+				bool is_current = (i == start_msg_count_);
+				if (is_current) {
+					ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
+				}
+
+				if (ImGui::Button(label, ScaledVec2(40, 40))) {
+					ctrl_commands_.emplace_back(ReplayCtrlCommand::SetRound, i);
+					pause_menu_opend_ = false;
+					SDL_ShowCursor(SDL_DISABLE);
+				}
+
+				if (ImGui::IsItemHovered()) {
+					ImGui::BeginTooltip();
+					if (i - 1 < log_file_.round_data_size()) {
+						const auto& rd = log_file_.round_data(i - 1);
+						if (rd.win_team() == 1) {
+							ImGui::TextColored(ImVec4(.42f, .79f, .99f, 1), "%s", strprintf(GdxsvLanguage::gdxT("%s Wins"), GdxsvLanguage::gdxT("Federation")).c_str());
+						} else if (rd.win_team() == 2) {
+							ImGui::TextColored(ImVec4(.97f, .23f, .35f, 1), "%s", strprintf(GdxsvLanguage::gdxT("%s Wins"), GdxsvLanguage::gdxT("Zeon")).c_str());
+						} else {
+							ImGui::TextDisabled("  -  ");
+						}
+
+						if (rd.used_ms_size() > 0) {
+							std::string renpo_ms, zeon_ms;
+							for (int j = 0; j < rd.used_ms_size(); ++j) {
+								if (j >= log_file_.users_size()) break;
+								int ms_id = rd.used_ms(j);
+								const char* ms_name = GdxsvLanguage::GetMSName(ms_id - 1);
+								std::string name = (ms_name && strlen(ms_name) > 0 ? ms_name : "Unknown");
+
+								if (log_file_.users(j).team() == 1) {
+									if (!renpo_ms.empty()) renpo_ms += " ";
+									renpo_ms += name;
+								} else if (log_file_.users(j).team() == 2) {
+									if (!zeon_ms.empty()) zeon_ms += " ";
+									zeon_ms += name;
+								}
+							}
+							if (!renpo_ms.empty() && !zeon_ms.empty()) {
+								ImGui::Text("%s vs %s", renpo_ms.c_str(), zeon_ms.c_str());
+							} else if (!renpo_ms.empty() || !zeon_ms.empty()) {
+								ImGui::Text("%s%s", renpo_ms.c_str(), zeon_ms.c_str());
+							}
+						}
+					} else {
+						ImGui::TextDisabled("  -  ");
+					}
+					ImGui::EndTooltip();
+				}
+
+				if (is_current) {
+					ImGui::PopStyleColor();
+				}
+
+				if (i < totalRounds) {
+					ImGui::SameLine();
+				}
+			}
+			ImGui::EndGroup();
 		}
 
 		ImGui::Separator();

--- a/core/gdxsv/gdxsv_backend_replay.h
+++ b/core/gdxsv/gdxsv_backend_replay.h
@@ -153,7 +153,6 @@ class GdxsvBackendReplay {
 	bool seeking_ = false;
 	int target_round_ = 0;
 	int target_frame_ = 0;
-	int pending_round_ = 0;
 	bool pause_menu_opend_ = false;
 	bool lbs_first_skip_ = false;
 	int ctrl_play_speed_ = 0;

--- a/core/gdxsv/gdxsv_replay_util.cpp
+++ b/core/gdxsv/gdxsv_replay_util.cpp
@@ -39,55 +39,8 @@ std::string os_PrecomposedString(std::string string);
 
 namespace {
 
-const std::array<const char*, 41> ms_names_array{{
-	"Gundam",
-	"Guncannon",
-	"GM",
-	"Old Zaku",
-	"Zaku",
-	"Char's Zaku",
-	"Gouf",
-	"Dom",
-	"Rick Dom",
-	"Gelgoog",
-	"Char's Gelgoog",
-	"Gyan",
-	"Gogg",
-	"Acguy",
-	"Z'Gok",
-	"Char's Z'Gok",
-	"Zock",
-	"Guntank",
-	"Zeong",
-	"Ground Type Gundam",
-	"Ground Type GM",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"",
-	"Elmeth", //33
-	"Ball", //34
-	"Braw Bro", //35
-	"Grublo", //36
-	"Zakrello", //37
-	"Bigro", //38
-	"Big Zam", //39
-	"Adzam", //40
-	"G-Fighter", //41
-}};
-
 static const char* ms_names(int id) {
-	if (id < 0 || id >= (int)ms_names_array.size()) return "?";
-	const char* name = ms_names_array[id];
-	if (strlen(name) == 0) return "";
-	return GdxsvLanguage::gdxT(name);
+	return GdxsvLanguage::GetMSName(id);
 }
 
 std::vector<int> parse_csv_ints(const std::string& s) {
@@ -915,7 +868,7 @@ void gdxsv_replay_server_tab() {
 				ImGui::SameLine();
 				ImGui::PushItemWidth(200.0f * scaling);
 				if (ImGui::BeginCombo("##UsedMSItems", ms_names(ms_selected), ImGuiComboFlags_HeightLargest)) {
-					for (u32 i = 0; i < ms_names_array.size(); i++) {
+					for (int i = 0; i < GdxsvLanguage::GetMSCount(); i++) {
 						const char* name = ms_names(i);
 						if (strlen(name) == 0) continue;
 						bool is_selected = i == ms_selected;

--- a/core/gdxsv/gdxsv_translation.cpp
+++ b/core/gdxsv/gdxsv_translation.cpp
@@ -101,6 +101,61 @@ const char* GdxsvLanguage::gdxT(const char* msg) {
 	}
 }
 
+static const char* ms_names_array[] = {
+	"Gundam",
+	"Guncannon",
+	"GM",
+	"Old Zaku",
+	"Zaku",
+	"Char's Zaku",
+	"Gouf",
+	"Dom",
+	"Rick Dom",
+	"Gelgoog",
+	"Char's Gelgoog",
+	"Gyan",
+	"Gogg",
+	"Acguy",
+	"Z'Gok",
+	"Char's Z'Gok",
+	"Zock",
+	"Guntank",
+	"Zeong",
+	"Ground Type Gundam",
+	"Ground Type GM",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"",
+	"Elmeth", //33
+	"Ball", //34
+	"Braw Bro", //35
+	"Grublo", //36
+	"Zakrello", //37
+	"Bigro", //38
+	"Big Zam", //39
+	"Adzam", //40
+	"G-Fighter", //41
+};
+
+const char* GdxsvLanguage::GetMSName(int id) {
+	if (id < 0 || id >= GetMSCount()) return "?";
+	const char* name = ms_names_array[id];
+	if (strlen(name) == 0) return "";
+	return gdxT(name);
+}
+
+int GdxsvLanguage::GetMSCount() {
+	return (int)(sizeof(ms_names_array) / sizeof(ms_names_array[0]));
+}
+
 #ifdef _WIN32
 #include <winnls.h>
 

--- a/core/gdxsv/gdxsv_translation.h
+++ b/core/gdxsv/gdxsv_translation.h
@@ -55,6 +55,8 @@ class GdxsvLanguage {
 	static Lang Language();
 	static std::string TextureDirectoryName();
 	static const char* gdxT(const char* msg);
+	static const char* GetMSName(int id);
+	static int GetMSCount();
 
    private:
 	static Lang LanguageFromOS();

--- a/resources/i18n-gdxsv/ja.po
+++ b/resources/i18n-gdxsv/ja.po
@@ -251,6 +251,9 @@ msgstr "連邦"
 msgid "Zeon"
 msgstr "ジオン"
 
+msgid "%s Wins"
+msgstr "%s 勝利"
+
 msgid "Gundam"
 msgstr "ガンダム"
 

--- a/resources/i18n-gdxsv/zh_HK.po
+++ b/resources/i18n-gdxsv/zh_HK.po
@@ -257,6 +257,9 @@ msgstr "聯邦"
 msgid "Zeon"
 msgstr "自護"
 
+msgid "%s Wins"
+msgstr "%s 獲勝"
+
 msgid "Gundam"
 msgstr "高達"
 


### PR DESCRIPTION
- Replace the round control slider with numbered buttons for more intuitive seeking
- Allow clicking the current round button to restart the round
- Enhance round tooltips with win status and MS list

![Mar-05-2026 17-45-46](https://github.com/user-attachments/assets/689f2ebd-d154-4c43-b0d8-9092d515284d)
