### PR TITLE
Implement platform-specific HTTPS latency check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1949,6 +1949,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 		core/gdxsv/gdxsv_emu_hooks.h
 		core/gdxsv/gdxsv_gui_settings.cpp
 		core/gdxsv/gdxsv_gui_settings.h
+		core/gdxsv/gdxsv_https_latency.h
 		core/gdxsv/gdxsv_key_display.cpp
 		core/gdxsv/gdxsv_key_display.h
 		core/gdxsv/gdxsv_network.cpp
@@ -1976,10 +1977,18 @@ set_source_files_properties(core/gdxsv/juice_helper.c PROPERTIES INCLUDE_DIRECTO
 if(WIN32)
 	set(CMAKE_VS_SDK_INCLUDE_DIRECTORIES ${CUSTOM_INCLUDE_DIRECTORIES})
 	target_sources(${PROJECT_NAME} PRIVATE core/gdxsv/textures.rc)
+	if(NOT WINDOWS_STORE)
+		target_sources(${PROJECT_NAME} PRIVATE core/gdxsv/gdxsv_https_latency_win.cpp)
+	endif()
+endif()
+if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT NINTENDO_SWITCH)
+	target_sources(${PROJECT_NAME} PRIVATE core/gdxsv/gdxsv_https_latency_curl.cpp)
 endif()
 if(APPLE)
 	set(ASSETS core/gdxsv/Textures)
-	target_sources(${PROJECT_NAME} PRIVATE ${ASSETS})
+	target_sources(${PROJECT_NAME} PRIVATE
+			core/gdxsv/gdxsv_https_latency_apple.mm
+			${ASSETS})
 	source_group("Resources" FILES ${ASSETS})
 	set_source_files_properties(${ASSETS} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 endif()

--- a/core/gdxsv/gdxsv_https_latency.h
+++ b/core/gdxsv/gdxsv_https_latency.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "build.h"
+
+#include <string>
+#include <vector>
+
+struct GdxsvHttpsLatencyResult {
+	bool ok = false;
+	int status = 0;
+	int min_ms = -1;
+	std::string error;
+	std::vector<int> attempts_ms;
+};
+
+#if defined(__APPLE__) || (defined(_WIN32) && !defined(TARGET_UWP)) || (defined(__linux__) && !defined(__ANDROID__))
+GdxsvHttpsLatencyResult measureGdxsvHttpsLatency(const std::string& host, const std::string& path, int attempts);
+#else
+#include <chrono>
+#include "oslib/http_client.h"
+
+// Degraded fallback for platforms without a dedicated persistent HTTPS HEAD implementation.
+// This measures generic http::get() calls and may include session/TLS setup overhead.
+static inline GdxsvHttpsLatencyResult measureGdxsvHttpsLatency(const std::string& host, const std::string& path, int attempts)
+{
+	GdxsvHttpsLatencyResult result;
+	const std::string url = "https://" + host + path;
+
+	std::vector<u8> body;
+	std::string content_type;
+	int rc = http::get(url, body, content_type);
+	if (!http::success(rc))
+	{
+		result.status = rc;
+		result.error = "warmup failed";
+		return result;
+	}
+
+	for (int i = 0; i < attempts; i++)
+	{
+		body.clear();
+		content_type.clear();
+		auto t1 = std::chrono::high_resolution_clock::now();
+		rc = http::get(url, body, content_type);
+		auto t2 = std::chrono::high_resolution_clock::now();
+		if (!http::success(rc))
+		{
+			result.status = rc;
+			result.error = "request failed";
+			return result;
+		}
+
+		const int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+		result.attempts_ms.push_back(rtt);
+		if (result.min_ms == -1 || rtt < result.min_ms)
+			result.min_ms = rtt;
+	}
+
+	result.ok = result.min_ms >= 0;
+	result.status = rc;
+	return result;
+}
+#endif

--- a/core/gdxsv/gdxsv_https_latency_apple.mm
+++ b/core/gdxsv/gdxsv_https_latency_apple.mm
@@ -1,0 +1,108 @@
+#import <Foundation/Foundation.h>
+
+#include <chrono>
+
+#include "gdxsv_https_latency.h"
+#include "oslib/http_client.h"
+
+namespace {
+
+struct HeadResponse {
+	int status = 0;
+	std::string error;
+};
+
+static HeadResponse performHead(NSURLSession *session, NSURLRequest *request)
+{
+	dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+	__block NSHTTPURLResponse *http_response = nil;
+	__block NSError *http_error = nil;
+
+	NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+		completionHandler:^(NSData *, NSURLResponse *response, NSError *error) {
+			if ([response isKindOfClass:[NSHTTPURLResponse class]])
+				http_response = [(NSHTTPURLResponse *)response retain];
+			if (error != nil)
+				http_error = [error retain];
+			dispatch_semaphore_signal(sema);
+		}];
+	[task resume];
+
+	dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+	HeadResponse result;
+	if (http_error != nil)
+	{
+		result.error = [[http_error localizedDescription] UTF8String];
+		[http_error release];
+	}
+	if (http_response != nil)
+	{
+		result.status = (int)[http_response statusCode];
+		[http_response release];
+	}
+
+	return result;
+}
+
+} // namespace
+
+GdxsvHttpsLatencyResult measureGdxsvHttpsLatency(const std::string& host, const std::string& path, int attempts)
+{
+	GdxsvHttpsLatencyResult result;
+
+	@autoreleasepool {
+		NSString *url = [NSString stringWithFormat:@"https://%s%s", host.c_str(), path.c_str()];
+		NSString *user_agent = [NSString stringWithCString:http::getUserAgent().c_str()
+			encoding:[NSString defaultCStringEncoding]];
+
+		NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
+		[request setHTTPMethod:@"HEAD"];
+		[request setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
+		[request setHTTPShouldHandleCookies:NO];
+		[request setValue:user_agent forHTTPHeaderField:@"User-Agent"];
+
+		NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+		configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+		configuration.HTTPShouldSetCookies = NO;
+		NSURLSession *session = [[NSURLSession sessionWithConfiguration:configuration] retain];
+
+		HeadResponse response = performHead(session, request);
+		if (!http::success(response.status))
+		{
+			result.status = response.status;
+			result.error = response.error.empty() ? "warmup failed" : response.error;
+			[session finishTasksAndInvalidate];
+			[session release];
+			return result;
+		}
+
+		for (int i = 0; i < attempts; i++)
+		{
+			auto t1 = std::chrono::high_resolution_clock::now();
+			response = performHead(session, request);
+			auto t2 = std::chrono::high_resolution_clock::now();
+
+			if (!http::success(response.status))
+			{
+				result.status = response.status;
+				result.error = response.error.empty() ? "request failed" : response.error;
+				[session finishTasksAndInvalidate];
+				[session release];
+				return result;
+			}
+
+			const int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+			result.attempts_ms.push_back(rtt);
+			if (result.min_ms == -1 || rtt < result.min_ms)
+				result.min_ms = rtt;
+			result.status = response.status;
+		}
+
+		[session finishTasksAndInvalidate];
+		[session release];
+	}
+
+	result.ok = result.min_ms >= 0;
+	return result;
+}

--- a/core/gdxsv/gdxsv_https_latency_curl.cpp
+++ b/core/gdxsv/gdxsv_https_latency_curl.cpp
@@ -1,0 +1,89 @@
+#include "gdxsv_https_latency.h"
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <chrono>
+
+#include <curl/curl.h>
+
+#include "oslib/http_client.h"
+
+namespace {
+
+static GdxsvHttpsLatencyResult failResult(CURLcode code, long status, const char *prefix)
+{
+	GdxsvHttpsLatencyResult result;
+	result.status = (int)status;
+	if (code != CURLE_OK)
+		result.error = std::string(prefix) + ": " + curl_easy_strerror(code);
+	else
+		result.error = prefix;
+	return result;
+}
+
+static CURLcode performHead(CURL *curl, long& status)
+{
+	CURLcode code = curl_easy_perform(curl);
+	status = 0;
+	if (code == CURLE_OK)
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+	return code;
+}
+
+} // namespace
+
+GdxsvHttpsLatencyResult measureGdxsvHttpsLatency(const std::string& host, const std::string& path, int attempts)
+{
+	GdxsvHttpsLatencyResult result;
+	const std::string url = "https://" + host + path;
+
+	CURL *curl = curl_easy_init();
+	if (curl == nullptr)
+	{
+		result.error = "curl_easy_init failed";
+		return result;
+	}
+
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, http::getUserAgent().c_str());
+	curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 5000L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 10000L);
+	curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+
+	long status = 0;
+	CURLcode code = performHead(curl, status);
+	if (code != CURLE_OK || !http::success((int)status))
+	{
+		curl_easy_cleanup(curl);
+		return failResult(code, status, "warmup failed");
+	}
+
+	for (int i = 0; i < attempts; i++)
+	{
+		auto t1 = std::chrono::high_resolution_clock::now();
+		code = performHead(curl, status);
+		auto t2 = std::chrono::high_resolution_clock::now();
+
+		if (code != CURLE_OK || !http::success((int)status))
+		{
+			curl_easy_cleanup(curl);
+			return failResult(code, status, "request failed");
+		}
+
+		const int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+		result.attempts_ms.push_back(rtt);
+		if (result.min_ms == -1 || rtt < result.min_ms)
+			result.min_ms = rtt;
+		result.status = (int)status;
+	}
+
+	curl_easy_cleanup(curl);
+
+	result.ok = result.min_ms >= 0;
+	return result;
+}
+
+#endif

--- a/core/gdxsv/gdxsv_https_latency_win.cpp
+++ b/core/gdxsv/gdxsv_https_latency_win.cpp
@@ -1,0 +1,130 @@
+#include "gdxsv_https_latency.h"
+
+#if defined(_WIN32) && !defined(TARGET_UWP)
+
+#include <chrono>
+
+#include <windows.h>
+#include <wininet.h>
+
+#include "oslib/http_client.h"
+
+namespace {
+
+static std::string wininetError(const char *prefix, DWORD error)
+{
+	return std::string(prefix) + ": " + std::to_string(error);
+}
+
+static bool queryStatus(HINTERNET request, int& status)
+{
+	DWORD value = 0;
+	DWORD size = sizeof(value);
+	DWORD index = 0;
+	if (!HttpQueryInfoA(request, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER, &value, &size, &index))
+		return false;
+	status = (int)value;
+	return true;
+}
+
+static bool performHead(HINTERNET connection, const std::string& path, int& status, std::string& error)
+{
+	const char *accept_types[] = {"*/*", nullptr};
+	HINTERNET request = HttpOpenRequestA(connection, "HEAD", path.c_str(), nullptr, nullptr, accept_types,
+		INTERNET_FLAG_SECURE | INTERNET_FLAG_KEEP_CONNECTION | INTERNET_FLAG_NO_CACHE_WRITE
+			| INTERNET_FLAG_NO_COOKIES | INTERNET_FLAG_NO_UI | INTERNET_FLAG_RELOAD,
+		0);
+	if (request == nullptr)
+	{
+		error = wininetError("HttpOpenRequest failed", GetLastError());
+		return false;
+	}
+
+	DWORD timeout = 10000;
+	InternetSetOptionA(request, INTERNET_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+	InternetSetOptionA(request, INTERNET_OPTION_SEND_TIMEOUT, &timeout, sizeof(timeout));
+
+	bool ok = true;
+	if (!HttpSendRequestA(request, nullptr, 0, nullptr, 0))
+	{
+		error = wininetError("HttpSendRequest failed", GetLastError());
+		ok = false;
+	}
+	else if (!queryStatus(request, status))
+	{
+		error = wininetError("HttpQueryInfo failed", GetLastError());
+		ok = false;
+	}
+
+	InternetCloseHandle(request);
+	return ok;
+}
+
+} // namespace
+
+GdxsvHttpsLatencyResult measureGdxsvHttpsLatency(const std::string& host, const std::string& path, int attempts)
+{
+	GdxsvHttpsLatencyResult result;
+
+	HINTERNET internet = InternetOpenA(http::getUserAgent().c_str(), INTERNET_OPEN_TYPE_PRECONFIG, nullptr, nullptr, 0);
+	if (internet == nullptr)
+	{
+		result.error = wininetError("InternetOpen failed", GetLastError());
+		return result;
+	}
+
+	DWORD timeout = 5000;
+	InternetSetOptionA(internet, INTERNET_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+
+	HINTERNET connection = InternetConnectA(internet, host.c_str(), INTERNET_DEFAULT_HTTPS_PORT, nullptr, nullptr,
+		INTERNET_SERVICE_HTTP, 0, 0);
+	if (connection == nullptr)
+	{
+		result.error = wininetError("InternetConnect failed", GetLastError());
+		InternetCloseHandle(internet);
+		return result;
+	}
+
+	int status = 0;
+	std::string error;
+	if (!performHead(connection, path, status, error) || !http::success(status))
+	{
+		result.status = status;
+		result.error = error.empty() ? "warmup failed" : error;
+		InternetCloseHandle(connection);
+		InternetCloseHandle(internet);
+		return result;
+	}
+
+	for (int i = 0; i < attempts; i++)
+	{
+		auto t1 = std::chrono::high_resolution_clock::now();
+		status = 0;
+		error.clear();
+		const bool ok = performHead(connection, path, status, error);
+		auto t2 = std::chrono::high_resolution_clock::now();
+
+		if (!ok || !http::success(status))
+		{
+			result.status = status;
+			result.error = error.empty() ? "request failed" : error;
+			InternetCloseHandle(connection);
+			InternetCloseHandle(internet);
+			return result;
+		}
+
+		const int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+		result.attempts_ms.push_back(rtt);
+		if (result.min_ms == -1 || rtt < result.min_ms)
+			result.min_ms = rtt;
+		result.status = status;
+	}
+
+	InternetCloseHandle(connection);
+	InternetCloseHandle(internet);
+
+	result.ok = result.min_ms >= 0;
+	return result;
+}
+
+#endif

--- a/core/gdxsv/gdxsv_network.cpp
+++ b/core/gdxsv/gdxsv_network.cpp
@@ -8,6 +8,7 @@
 #include "oslib/http_client.h"
 #include "sleep.h"
 #include "gdxsv.h"
+#include "gdxsv_https_latency.h"
 #include "juice_helper.h"
 
 #ifndef _WIN32
@@ -293,69 +294,26 @@ std::future<std::map<std::string, int>> gcp_ping_test() {
 
 		// Function to test a single region
 		auto test_region = [&get_path](const std::tuple<std::string, std::string, std::string> &region_host) -> std::pair<std::string, int> {
-			TcpClient client;
-			if (!client.Connect(std::get<1>(region_host).c_str(), 80)) {
-				ERROR_LOG(COMMON, "connect failed : %s", std::get<0>(region_host).c_str());
-				return {"", -1};
+			const GdxsvHttpsLatencyResult latency = measureGdxsvHttpsLatency(std::get<1>(region_host), get_path, 3);
+			for (size_t i = 0; i < latency.attempts_ms.size(); i++)
+			{
+				const int rtt = latency.attempts_ms[i];
+				NOTICE_LOG(COMMON, "%s : attempt %d: %d[ms]", std::get<2>(region_host).c_str(), (int)i + 1, rtt);
 			}
 
-			int min_rtt = -1;
-			for (int i = 0; i < 3; i++) {
-				std::stringstream ss;
-				ss << "HEAD " << get_path << " HTTP/1.1"
-				   << "\r\n";
-				ss << "Host: " << std::get<1>(region_host) << "\r\n";
-				ss << "User-Agent: flycast for gdxsv"
-				   << "\r\n";
-				ss << "Connection: keep-alive"
-				   << "\r\n";
-				ss << "Accept: */*"
-				   << "\r\n";
-				ss << "\r\n";  // end of header
-
-				auto request_header = ss.str();
-				auto t1 = std::chrono::high_resolution_clock::now();
-				int n = client.Send(request_header.c_str(), (int)request_header.size());
-				if (n < request_header.size()) {
-					ERROR_LOG(COMMON, "send failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
-					break;
-				}
-
-				char buf[1024] = {0};
-				n = client.Recv(buf, 1024);
-				if (n <= 0) {
-					ERROR_LOG(COMMON, "recv failed : %s (attempt %d)", std::get<0>(region_host).c_str(), i + 1);
-					break;
-				}
-
-				auto t2 = std::chrono::high_resolution_clock::now();
-				int rtt = (int)std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-				const std::string response_header(buf, n);
-				if (response_header.find("200 OK") == std::string::npos && response_header.find("302 Found") == std::string::npos) {
-					ERROR_LOG(COMMON, "error response : %s (attempt %d)", response_header.c_str(), i + 1);
-					break;
-				}
-
-				NOTICE_LOG(COMMON, "%s : attempt %d: %d[ms]", std::get<2>(region_host).c_str(), i + 1, rtt);
-
-				if (min_rtt == -1 || rtt < min_rtt) {
-					min_rtt = rtt;
-				}
-			}
-
-			client.Close();
-
-			if (min_rtt == -1) {
-				ERROR_LOG(COMMON, "Ping test failed for all attempts : %s", std::get<0>(region_host).c_str());
+			if (!latency.ok)
+			{
+				ERROR_LOG(COMMON, "Ping test failed : %s status=%d error=%s", std::get<0>(region_host).c_str(),
+						  latency.status, latency.error.c_str());
 				return {"", -1};
 			}
 
 			char latency_str[256];
-			snprintf(latency_str, 256, "%s : %d[ms]", std::get<2>(region_host).c_str(), min_rtt);
+			snprintf(latency_str, 256, "%s : %d[ms]", std::get<2>(region_host).c_str(), latency.min_ms);
 			NOTICE_LOG(COMMON, "%s", latency_str);
 			gdxsv.SetPingResult(std::string(latency_str));
 
-			return {std::get<0>(region_host), min_rtt};
+			return {std::get<0>(region_host), latency.min_ms};
 		};
 
 		// Execute ping tests with max 6 parallel workers


### PR DESCRIPTION
Replaces the ~broken~ HTTP latency measurement with a native HTTPS implementation.
- macOS: Uses NSURLSession with persistent tasks.
- Windows: Uses WinInet with INTERNET_FLAG_KEEP_CONNECTION.
- Linux: Uses libcurl with keep-alive enabled.
- Fallback: Maintains a basic http::get implementation for other platforms.