### PR TITLE
Reset texture cache on GGPO friend save scene

### DIFF
--- a/core/gdxsv/gdxsv_backend_rollback.cpp
+++ b/core/gdxsv/gdxsv_backend_rollback.cpp
@@ -88,6 +88,7 @@ void GdxsvBackendRollback::Reset() {
 	state_ = State::None;
 	is_local_test_ = false;
 	error_fast_return_ = false;
+	ggpo_game_renderer_reset_ = false;
 	osd_network_stat_ = false;
 	osd_network_stat_countdown_ = 0;
 	start_button_counter_ = 0;
@@ -299,6 +300,8 @@ void GdxsvBackendRollback::OnMainUiLoop() {
 
 	// Friend save scene
 	if (gdxsv_ReadMem8(COM_R_No0) == 4 && gdxsv_ReadMem8(COM_R_No0 + 5) == 4 && ggpo::active() && !ggpo::isInRollback()) {
+		ResetGgpoGameRendererState();
+
 		int frame = 0;
 		ggpo::getCurrentFrame(&frame);
 
@@ -414,6 +417,7 @@ void GdxsvBackendRollback::Open() {
 	NOTICE_LOG(COMMON, "GdxsvBackendRollback.Open");
 	recv_buf_.assign({0x0e, 0x61, 0x00, 0x22, 0x10, 0x31, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd});
 	state_ = State::McsSessionExchange;
+	ggpo_game_renderer_reset_ = false;
 	gdxsv.maxlag_ = 0;
 	ApplyPatch(true);
 	osd_network_stat_ = config::NetworkStats;
@@ -442,6 +446,14 @@ void GdxsvBackendRollback::Close() {
 	state_ = State::Closed;
 	EventManager::event(Event::GGPOGameEnd);
 	NOTICE_LOG(COMMON, "GdxsvBackendRollback.Close Done");
+}
+
+void GdxsvBackendRollback::ResetGgpoGameRendererState() {
+	if (ggpo_game_renderer_reset_) {
+		return;
+	}
+	ggpo_game_renderer_reset_ = true;
+	EventManager::event(Event::GGPOGameEnd);
 }
 
 u32 GdxsvBackendRollback::OnSockWrite(u32 addr, u32 size) {

--- a/core/gdxsv/gdxsv_backend_rollback.h
+++ b/core/gdxsv/gdxsv_backend_rollback.h
@@ -45,10 +45,12 @@ class GdxsvBackendRollback {
 	void ApplyPatch(bool first_time);
 	void RestorePatch();
 	void ProcessLbsMessage();
+	void ResetGgpoGameRendererState();
 
 	State state_ = State::None;
 	bool is_local_test_ = false;
 	bool error_fast_return_ = false;
+	bool ggpo_game_renderer_reset_ = false;
 	bool osd_network_stat_ = false;
 	int osd_network_stat_countdown_ = 0;
 	int start_button_counter_ = 0;


### PR DESCRIPTION
Trigger the existing `GGPOGameEnd` renderer reset when rollback reaches the post-battle friend save scene.

This clears stale custom texture cache state early enough for the scene without changing GGPO disconnect timing or session teardown behavior.

Should fix this glitch as captured in this live stream https://www.youtube.com/live/zNZGWfBclT8?t=622