### PR TITLE
Block updates from macOS security-isolated app copies (App Translocation)

### DIFF
--- a/core/gdxsv/gdxsv_emu_hooks.cpp
+++ b/core/gdxsv/gdxsv_emu_hooks.cpp
@@ -256,25 +256,46 @@ static void gdxsv_update_popup() {
 		ImGui::PopTextWrapPos();
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ScaledVec2(16.f, 3.f));
 		float currentwidth = ImGui::GetContentRegionAvail().x;
-		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
-		if (GdxsvUpdate::IsSupportSelfUpdate()) {
-			if (ImGui::Button("Update", ScaledVec2(100.f, 0.f))) {
-				self_update_result = gdxsv_update.StartSelfUpdate();
-				update_popup_shown = true;
-				ImGui::CloseCurrentPopup();
-			}
-		} else {
+		const bool app_translocated = GdxsvUpdate::IsAppTranslocated();
+		if (app_translocated) {
+			ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + uiScaled(400.f));
+			ImGui::TextWrapped("Please move Flycast-gdxsv.app to the /Applications folder, then reopen it to use the auto updater. Or download it and update manually.");
+			ImGui::PopTextWrapPos();
+			ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
 			if (ImGui::Button("Download", ScaledVec2(100.f, 0.f))) {
 				os_LaunchFromURL(GdxsvUpdate::DownloadPageURL());
 				update_popup_shown = true;
 				ImGui::CloseCurrentPopup();
 			}
-		}
-		ImGui::SameLine();
-		ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
-		if (ImGui::Button("Cancel", ScaledVec2(100.f, 0.f))) {
-			update_popup_shown = true;
-			ImGui::CloseCurrentPopup();
+
+			ImGui::SameLine();
+			ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
+			if (ImGui::Button("Cancel", ScaledVec2(100.f, 0.f))) {
+				update_popup_shown = true;
+				ImGui::CloseCurrentPopup();
+			}
+		} else {
+			ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x - uiScaled(55.f));
+			if (GdxsvUpdate::IsSupportSelfUpdate()) {
+				if (ImGui::Button("Update", ScaledVec2(100.f, 0.f))) {
+					self_update_result = gdxsv_update.StartSelfUpdate();
+					update_popup_shown = true;
+					ImGui::CloseCurrentPopup();
+				}
+			} else {
+				if (ImGui::Button("Download", ScaledVec2(100.f, 0.f))) {
+					os_LaunchFromURL(GdxsvUpdate::DownloadPageURL());
+					update_popup_shown = true;
+					ImGui::CloseCurrentPopup();
+				}
+			}
+
+			ImGui::SameLine();
+			ImGui::SetCursorPosX((currentwidth - uiScaled(100.f)) / 2.f + ImGui::GetStyle().WindowPadding.x + uiScaled(55.f));
+			if (ImGui::Button("Cancel", ScaledVec2(100.f, 0.f))) {
+				update_popup_shown = true;
+				ImGui::CloseCurrentPopup();
+			}
 		}
 		ImGui::SetItemDefaultFocus();
 		ImGui::PopStyleVar();

--- a/core/gdxsv/gdxsv_update.cpp
+++ b/core/gdxsv/gdxsv_update.cpp
@@ -117,6 +117,14 @@ bool GdxsvUpdate::IsSupportSelfUpdate() {
 #endif
 }
 
+bool GdxsvUpdate::IsAppTranslocated() {
+#if defined(__APPLE__) && !defined(TARGET_IPHONE)
+	return GetExecutablePath().find("/AppTranslocation/") != std::string::npos;
+#else
+	return false;
+#endif
+}
+
 void GdxsvUpdate::HandleReleaseJSON(const std::string& json_string, LatestVersionInfo& out) {
 	const std::regex tag_name_regex(R"|#|("tag_name":"(.*?)")|#|");
 	const std::string version_prefix = "gdxsv-";

--- a/core/gdxsv/gdxsv_update.h
+++ b/core/gdxsv/gdxsv_update.h
@@ -11,6 +11,7 @@ class GdxsvUpdate {
 	void FetchLatestVersionInfo();
 	std::string GetLatestVersionTag() const;
 	static bool IsSupportSelfUpdate();
+	static bool IsAppTranslocated();
 	static std::string DownloadPageURL();
 	std::shared_future<bool> StartSelfUpdate();
 	float SelfUpdateProgress() const;


### PR DESCRIPTION
Detect when macOS runs Flycast from a protected temporary location: App Translocation, formally known as Gatekeeper Path Randomisation (GRP)

```
(base) administrator@46596 ~ % ps -ww -p "$(pgrep -x Flycast)" -o command=
/private/var/folders/qm/q7v8jj0s5yv1_m4n9287r6lw0000gn/T/AppTranslocation/D6516E88-E56A-41CF-BA7B-06851883A4EE/d/Flycast-gdxsv.app/Contents/MacOS/Flycast
```

Instead of attempting an auto-update that will fail, prompt the user to move Flycast to /Applications or download the update manually

<img width="421" height="171" alt="image" src="https://github.com/user-attachments/assets/b9aca212-1efe-4736-a0ef-4ff5cfa14c78" />

